### PR TITLE
refactor(evaluator): drop dead resolve_primitive fallback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,9 +61,9 @@ mutability; it currently holds only the primitive bindings.
 - Implement `Default` for public structs when a sensible default exists.
 - Unit tests live in the same file under `#[cfg(test)] mod tests`; cross-stage tests go
   in `libsrs/tests/r5rs/`, CLI behaviour in `srs/tests/cli.rs`.
-- Primitives are registered as `SrsValue::Id("__add")`-style markers and dispatched by
-  name in `Evaluator::apply`; add new primitives in both `register_primitives` and
-  `resolve_primitive`.
+- Primitives are registered as `SrsValue::Id("__add")`-style markers (single source of
+  truth: `Evaluator::register_primitives`) and dispatched by name in `Evaluator::apply`;
+  add a new primitive in both places.
 - Operator lexemes (`+`, `-`, ...) are translated to `SrsValue::Id("+")` by the translator.
 
 ## Current capabilities

--- a/libsrs/src/interpretor/evaluator.rs
+++ b/libsrs/src/interpretor/evaluator.rs
@@ -13,6 +13,8 @@ impl Evaluator {
         Evaluator { env }
     }
 
+    /// Single registry for primitive operators. Add a new operator here and
+    /// in `Evaluator::apply`; no other mapping is needed.
     fn register_primitives(env: &EnvRef) {
         env.define("+", SrsValue::Id("__add".to_string()));
         env.define("-", SrsValue::Id("__sub".to_string()));
@@ -46,23 +48,12 @@ impl Evaluator {
     }
 
     fn eval_id(&self, name: &str) -> SrsResult<SrsValue> {
-        self.env
-            .get(name)
-            .or_else(|| self.resolve_primitive(name))
-            .ok_or_else(|| {
-                SrsError::with_message(
-                    SrsErrorKind::UnknownIdentifier,
-                    format!("unknown identifier: {}", name),
-                )
-            })
-    }
-
-    fn resolve_primitive(&self, name: &str) -> Option<SrsValue> {
-        match name {
-            "+" | "-" | "*" | "/" => Some(SrsValue::Id(format!("__{}", name))),
-            "exit" => Some(SrsValue::Id("__exit".to_string())),
-            _ => None,
-        }
+        self.env.get(name).ok_or_else(|| {
+            SrsError::with_message(
+                SrsErrorKind::UnknownIdentifier,
+                format!("unknown identifier: {}", name),
+            )
+        })
     }
 
     fn resolve(&self, name: &str) -> SrsValue {


### PR DESCRIPTION
Close #10

- delete `Evaluator::resolve_primitive` (dead code: the environment always resolves operators first)
- `eval_id` now resolves only through the environment
- `register_primitives` documented as the single place to add a new operator (plus `apply`)
- AGENTS.md updated to remove the stale `resolve_primitive` reference

All tests pass (unit + integration + CLI).