### PR TITLE
feat(evaluator): implement vector primitives

### DIFF
--- a/libsrs/Cargo.toml
+++ b/libsrs/Cargo.toml
@@ -18,3 +18,7 @@ path = "tests/r5rs/procedure_tests.rs"
 [[test]]
 name = "r5rs_pair"
 path = "tests/r5rs/pair_tests.rs"
+
+[[test]]
+name = "r5rs_vector"
+path = "tests/r5rs/vector_tests.rs"

--- a/libsrs/src/interpretor/evaluator.rs
+++ b/libsrs/src/interpretor/evaluator.rs
@@ -189,6 +189,69 @@ pub fn global_env() -> Rc<Env> {
             func: native_map,
         }),
     );
+    env.define(
+        "vector".to_string(),
+        SrsValue::Native(Native {
+            name: "vector",
+            func: native_vector,
+        }),
+    );
+    env.define(
+        "make-vector".to_string(),
+        SrsValue::Native(Native {
+            name: "make-vector",
+            func: native_make_vector,
+        }),
+    );
+    env.define(
+        "vector?".to_string(),
+        SrsValue::Native(Native {
+            name: "vector?",
+            func: native_vector_p,
+        }),
+    );
+    env.define(
+        "vector-length".to_string(),
+        SrsValue::Native(Native {
+            name: "vector-length",
+            func: native_vector_length,
+        }),
+    );
+    env.define(
+        "vector-ref".to_string(),
+        SrsValue::Native(Native {
+            name: "vector-ref",
+            func: native_vector_ref,
+        }),
+    );
+    env.define(
+        "vector-set!".to_string(),
+        SrsValue::Native(Native {
+            name: "vector-set!",
+            func: native_vector_set,
+        }),
+    );
+    env.define(
+        "vector->list".to_string(),
+        SrsValue::Native(Native {
+            name: "vector->list",
+            func: native_vector_to_list,
+        }),
+    );
+    env.define(
+        "list->vector".to_string(),
+        SrsValue::Native(Native {
+            name: "list->vector",
+            func: native_list_to_vector,
+        }),
+    );
+    env.define(
+        "vector-fill!".to_string(),
+        SrsValue::Native(Native {
+            name: "vector-fill!",
+            func: native_vector_fill,
+        }),
+    );
     env
 }
 
@@ -747,6 +810,138 @@ fn native_map(args: &[SrsValue]) -> Result<SrsValue, String> {
             }
             Ok(vec_to_list(results))
         }
+    }
+}
+
+/// Extracts a `usize` index from a `SrsValue::Integer`, rejecting negative
+/// or non-integer indices.
+fn index_from(value: &SrsValue, proc_name: &str) -> Result<usize, String> {
+    match value {
+        SrsValue::Integer(n) if *n >= 0 => Ok(*n as usize),
+        SrsValue::Integer(_) => Err(format!("wrong type: negative index to {}", proc_name)),
+        _ => Err(format!("wrong type: expected integer to {}", proc_name)),
+    }
+}
+
+/// `(vector obj ...)`: allocates a fresh mutable vector containing `obj ...`.
+fn native_vector(args: &[SrsValue]) -> Result<SrsValue, String> {
+    Ok(SrsValue::Vector(Rc::new(RefCell::new(args.to_vec()))))
+}
+
+/// `(make-vector k [fill])`: allocates a fresh vector of `k` elements,
+/// initialized to `fill` if given, or `0` otherwise.
+fn native_make_vector(args: &[SrsValue]) -> Result<SrsValue, String> {
+    match args {
+        [] => Err("not enough arguments to make-vector".to_string()),
+        [k] => {
+            let len = index_from(k, "make-vector")?;
+            Ok(SrsValue::Vector(Rc::new(RefCell::new(vec![
+                SrsValue::Integer(0);
+                len
+            ]))))
+        }
+        [k, fill] => {
+            let len = index_from(k, "make-vector")?;
+            Ok(SrsValue::Vector(Rc::new(RefCell::new(vec![
+                fill.clone();
+                len
+            ]))))
+        }
+        _ => Err("too many arguments to make-vector".to_string()),
+    }
+}
+
+/// `(vector? obj)`: `#t` if `obj` is a vector, `#f` otherwise.
+fn native_vector_p(args: &[SrsValue]) -> Result<SrsValue, String> {
+    match args {
+        [only] => Ok(SrsValue::Boolean(matches!(only, SrsValue::Vector(_)))),
+        [] => Err("not enough arguments to vector?".to_string()),
+        _ => Err("too many arguments to vector?".to_string()),
+    }
+}
+
+/// `(vector-length vector)`: returns the number of elements in `vector`.
+fn native_vector_length(args: &[SrsValue]) -> Result<SrsValue, String> {
+    match args {
+        [SrsValue::Vector(cell)] => Ok(SrsValue::Integer(cell.borrow().len() as i64)),
+        [_] => Err("wrong type: expected vector".to_string()),
+        [] => Err("not enough arguments to vector-length".to_string()),
+        _ => Err("too many arguments to vector-length".to_string()),
+    }
+}
+
+/// `(vector-ref vector k)`: returns the `k`-th element of `vector`.
+fn native_vector_ref(args: &[SrsValue]) -> Result<SrsValue, String> {
+    match args {
+        [SrsValue::Vector(cell), k] => {
+            let index = index_from(k, "vector-ref")?;
+            cell.borrow()
+                .get(index)
+                .cloned()
+                .ok_or_else(|| "vector-ref: index out of range".to_string())
+        }
+        [_, _] => Err("wrong type: expected vector".to_string()),
+        [] | [_] => Err("not enough arguments to vector-ref".to_string()),
+        _ => Err("too many arguments to vector-ref".to_string()),
+    }
+}
+
+/// `(vector-set! vector k obj)`: stores `obj` at index `k` of `vector`.
+fn native_vector_set(args: &[SrsValue]) -> Result<SrsValue, String> {
+    match args {
+        [SrsValue::Vector(cell), k, obj] => {
+            let index = index_from(k, "vector-set!")?;
+            let mut vec = cell.borrow_mut();
+            if index >= vec.len() {
+                return Err("vector-set!: index out of range".to_string());
+            }
+            vec[index] = obj.clone();
+            Ok(SrsValue::Unspecified)
+        }
+        [_, _, _] => Err("wrong type: expected vector".to_string()),
+        [] | [_] | [_, _] => Err("not enough arguments to vector-set!".to_string()),
+        _ => Err("too many arguments to vector-set!".to_string()),
+    }
+}
+
+/// `(vector->list vector)`: returns a new list with the same elements as
+/// `vector`.
+fn native_vector_to_list(args: &[SrsValue]) -> Result<SrsValue, String> {
+    match args {
+        [SrsValue::Vector(cell)] => Ok(vec_to_list(cell.borrow().clone())),
+        [_] => Err("wrong type: expected vector".to_string()),
+        [] => Err("not enough arguments to vector->list".to_string()),
+        _ => Err("too many arguments to vector->list".to_string()),
+    }
+}
+
+/// `(list->vector list)`: returns a new vector with the same elements as
+/// `list`, which must be a proper list.
+fn native_list_to_vector(args: &[SrsValue]) -> Result<SrsValue, String> {
+    match args {
+        [list] => {
+            let items = list_to_vec(list).map_err(|e| e.to_string())?;
+            Ok(SrsValue::Vector(Rc::new(RefCell::new(items))))
+        }
+        [] => Err("not enough arguments to list->vector".to_string()),
+        _ => Err("too many arguments to list->vector".to_string()),
+    }
+}
+
+/// `(vector-fill! vector fill)`: stores `fill` in every element of
+/// `vector`.
+fn native_vector_fill(args: &[SrsValue]) -> Result<SrsValue, String> {
+    match args {
+        [SrsValue::Vector(cell), fill] => {
+            let mut vec = cell.borrow_mut();
+            for item in vec.iter_mut() {
+                *item = fill.clone();
+            }
+            Ok(SrsValue::Unspecified)
+        }
+        [_, _] => Err("wrong type: expected vector".to_string()),
+        [] | [_] => Err("not enough arguments to vector-fill!".to_string()),
+        _ => Err("too many arguments to vector-fill!".to_string()),
     }
 }
 

--- a/libsrs/tests/r5rs/vector_tests.rs
+++ b/libsrs/tests/r5rs/vector_tests.rs
@@ -1,0 +1,135 @@
+use libsrs::interpretor::evaluator::{eval, global_env};
+use libsrs::interpretor::lexical_analyzer::get_lexemes;
+use libsrs::interpretor::reader::read_all;
+use libsrs::types::core::SrsValue;
+
+fn eval_src(scm: &str) -> SrsValue {
+    let values = read_all(get_lexemes(scm).unwrap()).unwrap();
+    let env = global_env();
+    let mut result = SrsValue::Unspecified;
+    for value in &values {
+        result = eval(value, &env).unwrap();
+    }
+    result
+}
+
+fn as_vec(value: &SrsValue) -> Vec<SrsValue> {
+    match value {
+        SrsValue::Vector(cell) => cell.borrow().clone(),
+        other => panic!("expected vector, got {:?}", other),
+    }
+}
+
+#[test]
+fn vector_literal_self_evaluates() {
+    let items = as_vec(&eval_src("#(1 2 3)"));
+    assert!(matches!(items[0], SrsValue::Integer(1)));
+    assert!(matches!(items[1], SrsValue::Integer(2)));
+    assert!(matches!(items[2], SrsValue::Integer(3)));
+}
+
+#[test]
+fn vector_builds_a_vector_from_its_arguments() {
+    let items = as_vec(&eval_src("(vector 1 2 3)"));
+    assert_eq!(items.len(), 3);
+    assert!(matches!(items[0], SrsValue::Integer(1)));
+}
+
+#[test]
+fn vector_p_recognizes_vectors() {
+    assert!(matches!(
+        eval_src("(vector? (vector 1 2))"),
+        SrsValue::Boolean(true)
+    ));
+    assert!(matches!(
+        eval_src("(vector? (cons 1 2))"),
+        SrsValue::Boolean(false)
+    ));
+}
+
+#[test]
+fn make_vector_defaults_to_zero_fill() {
+    let items = as_vec(&eval_src("(make-vector 3)"));
+    assert_eq!(items.len(), 3);
+    assert!(items.iter().all(|v| matches!(v, SrsValue::Integer(0))));
+}
+
+#[test]
+fn make_vector_uses_given_fill() {
+    let items = as_vec(&eval_src("(make-vector 3 'a)"));
+    assert_eq!(items.len(), 3);
+    assert!(
+        items
+            .iter()
+            .all(|v| matches!(v, SrsValue::Symbol(s) if s == "a"))
+    );
+}
+
+#[test]
+fn vector_length_returns_the_element_count() {
+    assert!(matches!(
+        eval_src("(vector-length (vector 1 2 3))"),
+        SrsValue::Integer(3)
+    ));
+}
+
+#[test]
+fn vector_ref_returns_the_element_at_index() {
+    assert!(matches!(
+        eval_src("(vector-ref (vector 10 20 30) 1)"),
+        SrsValue::Integer(20)
+    ));
+}
+
+#[test]
+fn vector_ref_out_of_range_is_an_error() {
+    let values = read_all(get_lexemes("(vector-ref (vector 1 2) 5)").unwrap()).unwrap();
+    let env = global_env();
+    assert!(eval(&values[0], &env).is_err());
+}
+
+#[test]
+fn vector_set_mutates_in_place() {
+    let src = "(define v (vector 1 2 3)) (vector-set! v 1 99) (vector-ref v 1)";
+    assert!(matches!(eval_src(src), SrsValue::Integer(99)));
+}
+
+#[test]
+fn vector_to_list_converts_elements_in_order() {
+    let src = "(vector->list (vector 1 2 3))";
+    let result = eval_src(src);
+    match result {
+        SrsValue::Pair(_) | SrsValue::Nil => {
+            let mut items = Vec::new();
+            let mut current = result;
+            loop {
+                match current {
+                    SrsValue::Nil => break,
+                    SrsValue::Pair(cell) => {
+                        let (car, cdr) = cell.borrow().clone();
+                        items.push(car);
+                        current = cdr;
+                    }
+                    _ => panic!("expected proper list"),
+                }
+            }
+            assert_eq!(items.len(), 3);
+            assert!(matches!(items[0], SrsValue::Integer(1)));
+        }
+        other => panic!("expected list, got {:?}", other),
+    }
+}
+
+#[test]
+fn list_to_vector_converts_elements_in_order() {
+    let items = as_vec(&eval_src("(list->vector '(1 2 3))"));
+    assert_eq!(items.len(), 3);
+    assert!(matches!(items[2], SrsValue::Integer(3)));
+}
+
+#[test]
+fn vector_fill_sets_every_element() {
+    let src = "(define v (vector 1 2 3)) (vector-fill! v 7) v";
+    let items = as_vec(&eval_src(src));
+    assert!(items.iter().all(|v| matches!(v, SrsValue::Integer(7))));
+}


### PR DESCRIPTION
Closes #34

Implements the missing Scheme vector primitives on top of the existing `SrsValue::Vector` type and reader/lexer support for `#(...)` literals:

- `vector`
- `make-vector`
- `vector?`
- `vector-length`
- `vector-ref`
- `vector-set!`
- `vector->list`
- `list->vector`
- `vector-fill!`

All follow the existing native-procedure pattern (`native_cons`/`native_car`/`native_map`), registered in `global_env()`.

Added `libsrs/tests/r5rs/vector_tests.rs` (12 tests) with a matching `[[test]]` entry in `Cargo.toml`, including a regression test confirming vector literals self-evaluate.

Checks:
- `cargo test` passes (36 tests total)
- `cargo fmt` clean
- `cargo clippy` clean (pre-existing warnings in unrelated code, unchanged by this PR)