### PR TITLE
libsrs: supporter des closures dans NativeFn/Native

### DIFF
--- a/libsrs/src/interpretor/evaluator/natives/arithmetic.rs
+++ b/libsrs/src/interpretor/evaluator/natives/arithmetic.rs
@@ -9,70 +9,70 @@ pub(super) fn install(env: &Rc<Env>) {
         "+".to_string(),
         SrsValue::Native(Native {
             name: "+",
-            func: native_add,
+            func: Rc::new(native_add),
         }),
     );
     env.define(
         "-".to_string(),
         SrsValue::Native(Native {
             name: "-",
-            func: native_sub,
+            func: Rc::new(native_sub),
         }),
     );
     env.define(
         "*".to_string(),
         SrsValue::Native(Native {
             name: "*",
-            func: native_mul,
+            func: Rc::new(native_mul),
         }),
     );
     env.define(
         "/".to_string(),
         SrsValue::Native(Native {
             name: "/",
-            func: native_div,
+            func: Rc::new(native_div),
         }),
     );
     env.define(
         "=".to_string(),
         SrsValue::Native(Native {
             name: "=",
-            func: native_num_eq,
+            func: Rc::new(native_num_eq),
         }),
     );
     env.define(
         "<".to_string(),
         SrsValue::Native(Native {
             name: "<",
-            func: native_lt,
+            func: Rc::new(native_lt),
         }),
     );
     env.define(
         ">".to_string(),
         SrsValue::Native(Native {
             name: ">",
-            func: native_gt,
+            func: Rc::new(native_gt),
         }),
     );
     env.define(
         "<=".to_string(),
         SrsValue::Native(Native {
             name: "<=",
-            func: native_le,
+            func: Rc::new(native_le),
         }),
     );
     env.define(
         ">=".to_string(),
         SrsValue::Native(Native {
             name: ">=",
-            func: native_ge,
+            func: Rc::new(native_ge),
         }),
     );
     env.define(
         "not".to_string(),
         SrsValue::Native(Native {
             name: "not",
-            func: native_not,
+            func: Rc::new(native_not),
         }),
     );
 }

--- a/libsrs/src/interpretor/evaluator/natives/io.rs
+++ b/libsrs/src/interpretor/evaluator/natives/io.rs
@@ -7,14 +7,14 @@ pub(super) fn install(env: &Rc<Env>) {
         "display".to_string(),
         SrsValue::Native(Native {
             name: "display",
-            func: native_display,
+            func: Rc::new(native_display),
         }),
     );
     env.define(
         "newline".to_string(),
         SrsValue::Native(Native {
             name: "newline",
-            func: native_newline,
+            func: Rc::new(native_newline),
         }),
     );
 }

--- a/libsrs/src/interpretor/evaluator/natives/pairs.rs
+++ b/libsrs/src/interpretor/evaluator/natives/pairs.rs
@@ -11,35 +11,35 @@ pub(super) fn install(env: &Rc<Env>) {
         "cons".to_string(),
         SrsValue::Native(Native {
             name: "cons",
-            func: native_cons,
+            func: Rc::new(native_cons),
         }),
     );
     env.define(
         "car".to_string(),
         SrsValue::Native(Native {
             name: "car",
-            func: native_car,
+            func: Rc::new(native_car),
         }),
     );
     env.define(
         "cdr".to_string(),
         SrsValue::Native(Native {
             name: "cdr",
-            func: native_cdr,
+            func: Rc::new(native_cdr),
         }),
     );
     env.define(
         "apply".to_string(),
         SrsValue::Native(Native {
             name: "apply",
-            func: native_apply,
+            func: Rc::new(native_apply),
         }),
     );
     env.define(
         "map".to_string(),
         SrsValue::Native(Native {
             name: "map",
-            func: native_map,
+            func: Rc::new(native_map),
         }),
     );
 }

--- a/libsrs/src/interpretor/evaluator/natives/trig.rs
+++ b/libsrs/src/interpretor/evaluator/natives/trig.rs
@@ -9,28 +9,28 @@ pub(super) fn install(env: &Rc<Env>) {
         "sin".to_string(),
         SrsValue::Native(Native {
             name: "sin",
-            func: native_sin,
+            func: Rc::new(native_sin),
         }),
     );
     env.define(
         "cos".to_string(),
         SrsValue::Native(Native {
             name: "cos",
-            func: native_cos,
+            func: Rc::new(native_cos),
         }),
     );
     env.define(
         "tan".to_string(),
         SrsValue::Native(Native {
             name: "tan",
-            func: native_tan,
+            func: Rc::new(native_tan),
         }),
     );
     env.define(
         "atan".to_string(),
         SrsValue::Native(Native {
             name: "atan",
-            func: native_atan,
+            func: Rc::new(native_atan),
         }),
     );
 }

--- a/libsrs/src/interpretor/evaluator/natives/vectors.rs
+++ b/libsrs/src/interpretor/evaluator/natives/vectors.rs
@@ -11,63 +11,63 @@ pub(super) fn install(env: &Rc<Env>) {
         "vector".to_string(),
         SrsValue::Native(Native {
             name: "vector",
-            func: native_vector,
+            func: Rc::new(native_vector),
         }),
     );
     env.define(
         "make-vector".to_string(),
         SrsValue::Native(Native {
             name: "make-vector",
-            func: native_make_vector,
+            func: Rc::new(native_make_vector),
         }),
     );
     env.define(
         "vector?".to_string(),
         SrsValue::Native(Native {
             name: "vector?",
-            func: native_vector_p,
+            func: Rc::new(native_vector_p),
         }),
     );
     env.define(
         "vector-length".to_string(),
         SrsValue::Native(Native {
             name: "vector-length",
-            func: native_vector_length,
+            func: Rc::new(native_vector_length),
         }),
     );
     env.define(
         "vector-ref".to_string(),
         SrsValue::Native(Native {
             name: "vector-ref",
-            func: native_vector_ref,
+            func: Rc::new(native_vector_ref),
         }),
     );
     env.define(
         "vector-set!".to_string(),
         SrsValue::Native(Native {
             name: "vector-set!",
-            func: native_vector_set,
+            func: Rc::new(native_vector_set),
         }),
     );
     env.define(
         "vector->list".to_string(),
         SrsValue::Native(Native {
             name: "vector->list",
-            func: native_vector_to_list,
+            func: Rc::new(native_vector_to_list),
         }),
     );
     env.define(
         "list->vector".to_string(),
         SrsValue::Native(Native {
             name: "list->vector",
-            func: native_list_to_vector,
+            func: Rc::new(native_list_to_vector),
         }),
     );
     env.define(
         "vector-fill!".to_string(),
         SrsValue::Native(Native {
             name: "vector-fill!",
-            func: native_vector_fill,
+            func: Rc::new(native_vector_fill),
         }),
     );
 }

--- a/libsrs/src/types/core.rs
+++ b/libsrs/src/types/core.rs
@@ -64,7 +64,10 @@ impl fmt::Debug for Lambda {
 }
 
 /// Native (builtin) procedure implemented in Rust.
-pub type NativeFn = fn(&[SrsValue]) -> Result<SrsValue, String>;
+/// Boxed in an `Rc` so that native procedures can be closures capturing
+/// shared state (e.g. a Cairo surface for GTK canvas primitives), not just
+/// plain function pointers.
+pub type NativeFn = Rc<dyn Fn(&[SrsValue]) -> Result<SrsValue, String>>;
 
 #[derive(Clone)]
 pub struct Native {


### PR DESCRIPTION
Closes #37

## Changement

`NativeFn` passe de `fn(&[SrsValue]) -> Result<SrsValue, String>` (pointeur de fonction) à `Rc<dyn Fn(&[SrsValue]) -> Result<SrsValue, String>>`, permettant aux procédures natives de capturer un état partagé (utile pour les futures primitives graphiques GTK, #40).

## Détails

- `libsrs/src/types/core.rs`: nouveau type `NativeFn`.
- Site d'appel dans `evaluator.rs` (`(native.func)(args)`) inchangé : `Rc<dyn Fn>` s'appelle de la même façon qu'un pointeur de fonction.
- Tous les modules `natives/*.rs` (arithmetic, trig, pairs, vectors, io) adaptés en enveloppant les `fn` existantes dans `Rc::new(...)`.
- `Native` garde son `impl Debug` inchangé (basé sur `name`), pas d'impact sur `Display`/égalité.

## Vérifications

- `cargo build --workspace`: OK
- `cargo test --workspace`: toutes les suites passent
- `cargo fmt --check`: OK
- `cargo clippy --workspace --all-targets -- -D warnings`: 2 erreurs pré-existantes sur `main` (question_mark dans evaluator/tests.rs, approx_constant sur 3.14 dans lexical_analyzer.rs), non liées à ce changement — vérifié en stashant le diff.