### PR TITLE
srsgtk: widget REPL (historique + multi-ligne)

### DIFF
--- a/libsrs/src/interpretor.rs
+++ b/libsrs/src/interpretor.rs
@@ -1,3 +1,4 @@
 pub mod evaluator;
 pub mod lexical_analyzer;
 pub mod reader;
+pub mod repl;

--- a/libsrs/src/interpretor/repl.rs
+++ b/libsrs/src/interpretor/repl.rs
@@ -1,0 +1,130 @@
+//! Shared REPL evaluation pipeline (lex -> read -> eval), reusable by any
+//! front-end (CLI, GTK widget, ...).
+//!
+//! The main feature on top of a naive `lex |> read |> eval` pipeline is the
+//! ability to tell apart a genuine syntax error from an *incomplete* input
+//! (e.g. an unclosed parenthesis or string): front-ends can use this to
+//! implement multi-line input, waiting for more source instead of reporting
+//! an error immediately.
+
+use std::rc::Rc;
+
+use crate::interpretor::evaluator::eval;
+use crate::interpretor::lexical_analyzer::{LexErrorKind, get_lexemes};
+use crate::interpretor::reader::{ReadErrorKind, read_all};
+use crate::types::core::{Env, SrsValue};
+
+/// Result of trying to evaluate a chunk of source text.
+#[derive(Debug)]
+pub enum EvalOutcome {
+    /// The source contained zero or more complete top-level forms, each
+    /// evaluated in order. The values are the results of each form, in
+    /// source order.
+    Done(Vec<SrsValue>),
+    /// The source is a valid prefix of a longer form (unclosed list,
+    /// unterminated string, ...): the caller should read more input and
+    /// try again with the concatenated source.
+    Incomplete,
+}
+
+/// Runs the `lex -> read -> eval` pipeline over `source`, evaluating every
+/// top-level form found in the given `env`.
+///
+/// Returns [`EvalOutcome::Incomplete`] when `source` looks like a truncated
+/// form rather than an invalid one, so that REPL front-ends can prompt for
+/// more input instead of surfacing a spurious error.
+pub fn eval_source(source: &str, env: &Rc<Env>) -> Result<EvalOutcome, String> {
+    let lexemes = match get_lexemes(source) {
+        Ok(lexemes) => lexemes,
+        Err(e) if is_incomplete_lex_error(&e.kind) => return Ok(EvalOutcome::Incomplete),
+        Err(e) => return Err(e.to_string()),
+    };
+
+    let values = match read_all(lexemes) {
+        Ok(values) => values,
+        Err(e) if e.kind == ReadErrorKind::UnexpectedEof => return Ok(EvalOutcome::Incomplete),
+        Err(e) => return Err(e.to_string()),
+    };
+
+    let mut results = Vec::with_capacity(values.len());
+    for value in &values {
+        match eval(value, env) {
+            Ok(result) => results.push(result),
+            Err(e) => return Err(e.to_string()),
+        }
+    }
+
+    Ok(EvalOutcome::Done(results))
+}
+
+/// Whether a lexical error stems from input ending prematurely (unclosed
+/// string, character literal, block comment, ...) rather than from an
+/// actually malformed token.
+fn is_incomplete_lex_error(kind: &LexErrorKind) -> bool {
+    matches!(
+        kind,
+        LexErrorKind::UnterminatedCharacter
+            | LexErrorKind::UnterminatedSharpDispatch
+            | LexErrorKind::UnterminatedBlockComment
+            | LexErrorKind::UnterminatedString
+            | LexErrorKind::UnterminatedExponent
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::interpretor::evaluator::global_env;
+
+    #[test]
+    fn evaluates_complete_forms_in_order() {
+        let env = global_env();
+        let outcome = eval_source("(+ 1 2) (* 2 3)", &env).unwrap();
+        match outcome {
+            EvalOutcome::Done(values) => {
+                assert_eq!(values.len(), 2);
+                assert!(matches!(values[0], SrsValue::Integer(3)));
+                assert!(matches!(values[1], SrsValue::Integer(6)));
+            }
+            EvalOutcome::Incomplete => panic!("expected complete evaluation"),
+        }
+    }
+
+    #[test]
+    fn reports_incomplete_unclosed_list() {
+        let env = global_env();
+        let outcome = eval_source("(+ 1 2", &env).unwrap();
+        assert!(matches!(outcome, EvalOutcome::Incomplete));
+    }
+
+    #[test]
+    fn reports_incomplete_unterminated_string() {
+        let env = global_env();
+        let outcome = eval_source("(display \"hello", &env).unwrap();
+        assert!(matches!(outcome, EvalOutcome::Incomplete));
+    }
+
+    #[test]
+    fn reports_genuine_errors_as_such() {
+        let env = global_env();
+        let err = eval_source("(unbound-symbol)", &env).unwrap_err();
+        assert!(!err.is_empty());
+    }
+
+    #[test]
+    fn continuation_can_complete_a_pending_form() {
+        let env = global_env();
+        assert!(matches!(
+            eval_source("(+ 1", &env).unwrap(),
+            EvalOutcome::Incomplete
+        ));
+        let outcome = eval_source("(+ 1\n2)", &env).unwrap();
+        match outcome {
+            EvalOutcome::Done(values) => {
+                assert_eq!(values.len(), 1);
+                assert!(matches!(values[0], SrsValue::Integer(3)));
+            }
+            EvalOutcome::Incomplete => panic!("expected complete evaluation"),
+        }
+    }
+}

--- a/srs/src/main.rs
+++ b/srs/src/main.rs
@@ -1,9 +1,8 @@
 use std::io::{self, Write};
 use std::rc::Rc;
 
-use libsrs::interpretor::evaluator::{eval, global_env};
-use libsrs::interpretor::lexical_analyzer::get_lexemes;
-use libsrs::interpretor::reader::read_all;
+use libsrs::interpretor::evaluator::global_env;
+use libsrs::interpretor::repl::{EvalOutcome, eval_source};
 use libsrs::types::core::{Env, SrsValue};
 
 fn main() {
@@ -41,16 +40,18 @@ fn main() {
 }
 
 fn eval_line(line: &str, env: &Rc<Env>) -> Result<(), String> {
-    let lexemes = get_lexemes(line).map_err(|e| e.to_string())?;
-    let values = read_all(lexemes).map_err(|e| e.to_string())?;
-
-    for value in &values {
-        match eval(value, env) {
-            Ok(SrsValue::Unspecified) => {}
-            Ok(result) => println!("{}", result),
-            Err(e) => return Err(e.to_string()),
+    match eval_source(line, env)? {
+        // The CLI evaluates one line at a time and doesn't support
+        // multi-line input: an incomplete form is just reported as an
+        // error, same as before this pipeline was factored out.
+        EvalOutcome::Incomplete => Err("unexpected end of input".to_string()),
+        EvalOutcome::Done(values) => {
+            for value in values {
+                if !matches!(value, SrsValue::Unspecified) {
+                    println!("{}", value);
+                }
+            }
+            Ok(())
         }
     }
-
-    Ok(())
 }

--- a/srsgtk/src/main.rs
+++ b/srsgtk/src/main.rs
@@ -1,5 +1,7 @@
 use gtk4::prelude::*;
-use gtk4::{Application, ApplicationWindow, DrawingArea, Label, Orientation, Paned};
+use gtk4::{Application, ApplicationWindow, DrawingArea, Orientation, Paned};
+
+mod repl;
 
 const APP_ID: &str = "org.srs.srsgtk";
 const WINDOW_WIDTH: i32 = 800;
@@ -26,12 +28,12 @@ fn build_ui(app: &Application) {
         let _ = cr.fill();
     });
 
-    let repl_placeholder = Label::new(Some("REPL (placeholder)"));
-    repl_placeholder.set_vexpand(true);
-    repl_placeholder.set_hexpand(true);
+    let repl_widget = repl::build_repl_widget();
+    repl_widget.set_vexpand(true);
+    repl_widget.set_hexpand(true);
 
     paned.set_start_child(Some(&drawing_area));
-    paned.set_end_child(Some(&repl_placeholder));
+    paned.set_end_child(Some(&repl_widget));
     paned.set_resize_start_child(true);
     paned.set_resize_end_child(true);
     paned.set_shrink_start_child(false);

--- a/srsgtk/src/repl.rs
+++ b/srsgtk/src/repl.rs
@@ -1,0 +1,217 @@
+//! Scheme REPL widget: an output log (read-only, scrollable) plus an
+//! input entry supporting multi-line forms and command history.
+
+use std::cell::{Cell, RefCell};
+use std::rc::Rc;
+
+use gtk4::gdk::Key;
+use gtk4::glib;
+use gtk4::prelude::*;
+use gtk4::{
+    Box as GtkBox, Entry, EventControllerKey, Orientation, PolicyType, ScrolledWindow, TextBuffer,
+    TextView, WrapMode,
+};
+
+use libsrs::interpretor::evaluator::global_env;
+use libsrs::interpretor::repl::{EvalOutcome, eval_source};
+use libsrs::types::core::{Env, SrsValue};
+
+/// Mutable state shared by the REPL widget's callbacks.
+struct ReplState {
+    env: Rc<Env>,
+    /// Source accumulated so far for a form spanning multiple lines
+    /// (empty when no form is in progress).
+    pending: RefCell<String>,
+    /// Previously submitted (complete) top-level forms, oldest first.
+    history: RefCell<Vec<String>>,
+    /// Index into `history` currently shown in the entry while
+    /// navigating with Up/Down, and the draft that was being typed
+    /// before navigation started.
+    history_cursor: Cell<Option<usize>>,
+    draft: RefCell<String>,
+}
+
+/// Builds the REPL widget: a scrollable output log on top of a single-line
+/// input entry. Returns the top-level widget to embed in the window.
+pub fn build_repl_widget() -> GtkBox {
+    let output_buffer = TextBuffer::builder().build();
+    let error_tag = output_buffer
+        .create_tag(Some("error"), &[("foreground", &"#e06c75")])
+        .expect("creating the 'error' text tag should not fail");
+    let prompt_tag = output_buffer
+        .create_tag(Some("prompt"), &[("foreground", &"#61afef")])
+        .expect("creating the 'prompt' text tag should not fail");
+
+    let output_view = TextView::builder()
+        .buffer(&output_buffer)
+        .editable(false)
+        .cursor_visible(false)
+        .monospace(true)
+        .wrap_mode(WrapMode::WordChar)
+        .build();
+
+    let scrolled = ScrolledWindow::builder()
+        .hscrollbar_policy(PolicyType::Never)
+        .vscrollbar_policy(PolicyType::Automatic)
+        .vexpand(true)
+        .hexpand(true)
+        .child(&output_view)
+        .build();
+
+    let input = Entry::builder()
+        .placeholder_text("srs>")
+        .hexpand(true)
+        .build();
+
+    let state = Rc::new(ReplState {
+        env: global_env(),
+        pending: RefCell::new(String::new()),
+        history: RefCell::new(Vec::new()),
+        history_cursor: Cell::new(None),
+        draft: RefCell::new(String::new()),
+    });
+
+    append_line(&output_buffer, &output_view, "srs REPL", None);
+
+    {
+        let state = state.clone();
+        let output_buffer = output_buffer.clone();
+        let output_view = output_view.clone();
+        let error_tag = error_tag.clone();
+        let prompt_tag = prompt_tag.clone();
+        input.connect_activate(move |entry| {
+            let line = entry.text().to_string();
+            let prompt = if state.pending.borrow().is_empty() {
+                "srs>"
+            } else {
+                "..."
+            };
+            append_line(
+                &output_buffer,
+                &output_view,
+                &format!("{prompt} {line}"),
+                Some(&prompt_tag),
+            );
+
+            let source = {
+                let pending = state.pending.borrow();
+                if pending.is_empty() {
+                    line.clone()
+                } else {
+                    format!("{}\n{}", pending, line)
+                }
+            };
+
+            match eval_source(&source, &state.env) {
+                Ok(EvalOutcome::Incomplete) => {
+                    *state.pending.borrow_mut() = source;
+                    entry.set_placeholder_text(Some("..."));
+                }
+                Ok(EvalOutcome::Done(values)) => {
+                    for value in values {
+                        if !matches!(value, SrsValue::Unspecified) {
+                            append_line(&output_buffer, &output_view, &value.to_string(), None);
+                        }
+                    }
+                    state.history.borrow_mut().push(source);
+                    state.pending.borrow_mut().clear();
+                    entry.set_placeholder_text(Some("srs>"));
+                }
+                Err(e) => {
+                    append_line(
+                        &output_buffer,
+                        &output_view,
+                        &format!("erreur: {e}"),
+                        Some(&error_tag),
+                    );
+                    state.pending.borrow_mut().clear();
+                    entry.set_placeholder_text(Some("srs>"));
+                }
+            }
+
+            entry.set_text("");
+            state.history_cursor.set(None);
+        });
+    }
+
+    let key_controller = EventControllerKey::new();
+    {
+        let state = state.clone();
+        let input = input.clone();
+        key_controller.connect_key_pressed(move |_controller, key, _code, _modifiers| match key {
+            Key::Up => {
+                navigate_history(&state, &input, -1);
+                glib::Propagation::Stop
+            }
+            Key::Down => {
+                navigate_history(&state, &input, 1);
+                glib::Propagation::Stop
+            }
+            _ => glib::Propagation::Proceed,
+        });
+    }
+    input.add_controller(key_controller);
+
+    let container = GtkBox::new(Orientation::Vertical, 4);
+    container.set_vexpand(true);
+    container.set_hexpand(true);
+    container.append(&scrolled);
+    container.append(&input);
+
+    container
+}
+
+/// Moves the history cursor by `delta` (-1 for older, +1 for newer) and
+/// updates the entry's text accordingly. Only navigates when no
+/// multi-line form is pending, to avoid clobbering the entry's role as a
+/// continuation prompt.
+fn navigate_history(state: &Rc<ReplState>, entry: &Entry, delta: i32) {
+    if !state.pending.borrow().is_empty() {
+        return;
+    }
+
+    let history = state.history.borrow();
+    if history.is_empty() {
+        return;
+    }
+
+    let current = state.history_cursor.get();
+    let next = match (current, delta) {
+        (None, -1) => Some(history.len() - 1),
+        (None, 1) => None,
+        (Some(i), -1) => Some(i.saturating_sub(1)),
+        (Some(i), 1) if i + 1 < history.len() => Some(i + 1),
+        (Some(_), 1) => None,
+        _ => current,
+    };
+
+    if current.is_none() && delta == -1 {
+        *state.draft.borrow_mut() = entry.text().to_string();
+    }
+
+    match next {
+        Some(i) => entry.set_text(&history[i]),
+        None => entry.set_text(&state.draft.borrow()),
+    }
+    entry.set_position(-1);
+    state.history_cursor.set(next);
+}
+
+/// Appends `text` followed by a newline to the output log, applying `tag`
+/// (if any) to the whole line, then scrolls the view to keep it visible.
+fn append_line(buffer: &TextBuffer, view: &TextView, text: &str, tag: Option<&gtk4::TextTag>) {
+    let mut start = buffer.end_iter();
+    let start_offset = start.offset();
+    buffer.insert(&mut start, text);
+    buffer.insert(&mut buffer.end_iter(), "\n");
+
+    if let Some(tag) = tag {
+        let start_iter = buffer.iter_at_offset(start_offset);
+        let end_iter = buffer.end_iter();
+        buffer.apply_tag(tag, &start_iter, &end_iter);
+    }
+
+    let end_mark = buffer.create_mark(None, &buffer.end_iter(), false);
+    view.scroll_mark_onscreen(&end_mark);
+    buffer.delete_mark(&end_mark);
+}


### PR DESCRIPTION
Closes #39.

## Changements

- `libsrs`: nouveau module `interpretor::repl` (`eval_source`) qui factorise le pipeline lex -> read -> eval. Il distingue les vraies erreurs de syntaxe d'une entrée simplement incomplète (parenthèse non fermée, chaîne non terminée, etc.) via `EvalOutcome::Incomplete`, pour permettre aux fronts (CLI, GTK) de gérer la saisie multi-ligne.
- `srs`: le REPL CLI est refactoré pour réutiliser `eval_source` (comportement inchangé : une forme incomplète reste une erreur, comme avant).
- `srsgtk`: le placeholder REPL est remplacé par un vrai widget :
  - `gtk::TextView` en lecture seule et scrollable pour l'historique des entrées/résultats/erreurs (prompts et erreurs en couleur distincte).
  - `gtk::Entry` pour la saisie.
  - Support multi-ligne : si une forme n'est pas complète, pas d'erreur affichée, juste un prompt de continuation (`...`) en attendant la suite.
  - Navigation flèches haut/bas dans l'historique des formes précédemment soumises.
  - Toute l'évaluation reste sur le thread principal GTK.

## Vérifications

- `cargo fmt --all --check` : OK
- `cargo clippy --workspace -- -D warnings` : OK (aucun nouveau warning)
- `cargo test --workspace --lib --bins` : OK, dont 5 nouveaux tests pour `eval_source`