### PR TITLE
feat(evaluator): implement max builtin procedure

### DIFF
--- a/libsrs/src/interpretor/evaluator/natives/arithmetic.rs
+++ b/libsrs/src/interpretor/evaluator/natives/arithmetic.rs
@@ -2,7 +2,7 @@ use std::rc::Rc;
 
 use crate::types::core::{Env, Native, SrsValue};
 
-use super::{compare_chain, fold_numbers, negate, reciprocal};
+use super::{compare_chain, fold_numbers, negate, numeric_cmp, numeric_to_f64, reciprocal};
 
 pub(super) fn install(env: &Rc<Env>) {
     env.define(
@@ -69,6 +69,13 @@ pub(super) fn install(env: &Rc<Env>) {
         }),
     );
     env.define(
+        "max".to_string(),
+        SrsValue::Native(Native {
+            name: "max",
+            func: Rc::new(native_max),
+        }),
+    );
+    env.define(
         "not".to_string(),
         SrsValue::Native(Native {
             name: "not",
@@ -132,6 +139,30 @@ fn native_le(args: &[SrsValue]) -> Result<SrsValue, String> {
 
 fn native_ge(args: &[SrsValue]) -> Result<SrsValue, String> {
     compare_chain(">=", args, |ord| ord != std::cmp::Ordering::Less)
+}
+
+/// `(max n1 n2 ...)`: returns the largest of its arguments. Per R5RS, if
+/// any argument is inexact (`Float`), the result is coerced to inexact
+/// even when the largest value came from an exact argument.
+fn native_max(args: &[SrsValue]) -> Result<SrsValue, String> {
+    match args {
+        [] => Err("not enough arguments to max".to_string()),
+        [first, rest @ ..] => {
+            let mut best = first.clone();
+            let mut inexact = matches!(first, SrsValue::Float(_));
+            for value in rest {
+                inexact |= matches!(value, SrsValue::Float(_));
+                if numeric_cmp(value, &best)? == std::cmp::Ordering::Greater {
+                    best = value.clone();
+                }
+            }
+            if inexact && !matches!(best, SrsValue::Float(_)) {
+                Ok(SrsValue::Float(numeric_to_f64(&best)?))
+            } else {
+                Ok(best)
+            }
+        }
+    }
 }
 
 /// `(not obj)`: `#t` if `obj` is `#f`, `#f` for any other value (per R5RS,

--- a/libsrs/src/interpretor/evaluator/tests.rs
+++ b/libsrs/src/interpretor/evaluator/tests.rs
@@ -93,6 +93,29 @@ fn float_coercion() {
 }
 
 #[test]
+fn max_of_several_integers() {
+    assert!(matches!(ok("(max 1 3 2)"), SrsValue::Integer(3)));
+}
+
+#[test]
+fn max_single_argument() {
+    assert!(matches!(ok("(max 5)"), SrsValue::Integer(5)));
+}
+
+#[test]
+fn max_no_args_fails() {
+    assert!(eval_src("(max)").is_err());
+}
+
+#[test]
+fn max_inexact_contagion() {
+    match ok("(max 1 2.0)") {
+        SrsValue::Float(f) => assert!((f - 2.0).abs() < f64::EPSILON),
+        other => panic!("expected float, got {:?}", other),
+    }
+}
+
+#[test]
 fn sin_of_zero() {
     match ok("(sin 0)") {
         SrsValue::Float(f) => assert!((f - 0.0).abs() < f64::EPSILON),


### PR DESCRIPTION
Adds R5RS-style variadic `max` procedure to the native arithmetic builtins, following the same pattern as `+`, `-`, `<`, etc.

- `(max 1 2 3)` => `3`
- `(max 5)` => `5`
- `(max)` => error
- Inexact contagion: if any argument is a `Float`, the result is coerced to `Float` even if the largest value came from an exact argument.

Tests added in `libsrs/src/interpretor/evaluator/tests.rs`.

Closes #47