### PR TITLE
feat(io): expose eof-object and eof-object? primitives

### DIFF
--- a/libsrs/Cargo.toml
+++ b/libsrs/Cargo.toml
@@ -22,3 +22,7 @@ path = "tests/r5rs/pair_tests.rs"
 [[test]]
 name = "r5rs_vector"
 path = "tests/r5rs/vector_tests.rs"
+
+[[test]]
+name = "r5rs_io"
+path = "tests/r5rs/io_tests.rs"

--- a/libsrs/src/interpretor/evaluator/natives/io.rs
+++ b/libsrs/src/interpretor/evaluator/natives/io.rs
@@ -17,6 +17,20 @@ pub(super) fn install(env: &Rc<Env>) {
             func: Rc::new(native_newline),
         }),
     );
+    env.define(
+        "eof-object".to_string(),
+        SrsValue::Native(Native {
+            name: "eof-object",
+            func: Rc::new(native_eof_object),
+        }),
+    );
+    env.define(
+        "eof-object?".to_string(),
+        SrsValue::Native(Native {
+            name: "eof-object?",
+            func: Rc::new(native_eof_object_p),
+        }),
+    );
 }
 
 /// `(display value)`: writes `value` to standard output using its
@@ -50,5 +64,24 @@ fn native_newline(args: &[SrsValue]) -> Result<SrsValue, String> {
             Ok(SrsValue::Unspecified)
         }
         _ => Err("too many arguments to newline".to_string()),
+    }
+}
+
+/// `(eof-object)`: returns the canonical end-of-file object.
+/// There is only one EOF value, represented by [`SrsValue::Eof`].
+fn native_eof_object(args: &[SrsValue]) -> Result<SrsValue, String> {
+    match args {
+        [] => Ok(SrsValue::Eof),
+        _ => Err("too many arguments to eof-object".to_string()),
+    }
+}
+
+/// `(eof-object? value)`: returns `#t` if `value` is the end-of-file
+/// object, `#f` otherwise.
+fn native_eof_object_p(args: &[SrsValue]) -> Result<SrsValue, String> {
+    match args {
+        [value] => Ok(SrsValue::Boolean(matches!(value, SrsValue::Eof))),
+        [] => Err("not enough arguments to eof-object?".to_string()),
+        _ => Err("too many arguments to eof-object?".to_string()),
     }
 }

--- a/libsrs/src/interpretor/evaluator/tests.rs
+++ b/libsrs/src/interpretor/evaluator/tests.rs
@@ -8,8 +8,8 @@ fn eval_src(src: &str) -> Result<SrsValue, EvalError> {
     let mut result = Ok(SrsValue::Unspecified);
     for value in &values {
         result = eval(value, &env);
-        if result.is_err() {
-            return result;
+        if let Err(ref err) = result {
+            return Err(err.clone());
         }
     }
     result

--- a/libsrs/src/interpretor/lexical_analyzer.rs
+++ b/libsrs/src/interpretor/lexical_analyzer.rs
@@ -658,6 +658,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::approx_constant)]
     fn integer_and_float() {
         assert_eq!(
             get_lexemes("42 3.14 1e10 -3.2e-5").unwrap(),

--- a/libsrs/tests/r5rs/io_tests.rs
+++ b/libsrs/tests/r5rs/io_tests.rs
@@ -1,0 +1,35 @@
+use libsrs::interpretor::evaluator::{eval, global_env};
+use libsrs::interpretor::lexical_analyzer::get_lexemes;
+use libsrs::interpretor::reader::read_all;
+use libsrs::types::core::SrsValue;
+
+fn eval_src(scm: &str) -> SrsValue {
+    let values = read_all(get_lexemes(scm).unwrap()).unwrap();
+    let env = global_env();
+    let mut result = SrsValue::Unspecified;
+    for value in &values {
+        result = eval(value, &env).unwrap();
+    }
+    result
+}
+
+#[test]
+fn eof_object_returns_eof_value() {
+    assert!(matches!(eval_src("(eof-object)"), SrsValue::Eof));
+}
+
+#[test]
+fn eof_object_p_returns_true_for_eof_object() {
+    assert!(matches!(
+        eval_src("(eof-object? (eof-object))"),
+        SrsValue::Boolean(true)
+    ));
+}
+
+#[test]
+fn eof_object_p_returns_false_for_non_eof_values() {
+    assert!(matches!(
+        eval_src("(eof-object? 42)"),
+        SrsValue::Boolean(false)
+    ));
+}


### PR DESCRIPTION
Implements issue #50.\n\n- Adds eof-object and eof-object? to natives/io.rs, reusing SrsValue::Eof.\n- Adds integration tests in libsrs/tests/r5rs/io_tests.rs.\n- Fixes pre-existing clippy warnings so CI stays green.\n\nCloses #50