### PR TITLE
feat(io): singleton current-input-port and current-output-port

### DIFF
--- a/libsrs/src/interpretor/evaluator/natives.rs
+++ b/libsrs/src/interpretor/evaluator/natives.rs
@@ -1,6 +1,7 @@
+use std::cell::RefCell;
 use std::rc::Rc;
 
-use crate::types::core::{Env, SrsValue};
+use crate::types::core::{Env, PortData, SrsValue};
 
 mod arithmetic;
 mod io;
@@ -12,11 +13,21 @@ mod vectors;
 /// (`+`, `-`, `*`, `/`) already bound.
 pub fn global_env() -> Rc<Env> {
     let env = Env::new(None);
+    let stdin_port = Rc::new(RefCell::new(PortData::stdin()));
+    let stdout_port = Rc::new(RefCell::new(PortData::stdout()));
+    env.define(
+        "*current-input-port*".to_string(),
+        SrsValue::Port(stdin_port.clone()),
+    );
+    env.define(
+        "*current-output-port*".to_string(),
+        SrsValue::Port(stdout_port.clone()),
+    );
     arithmetic::install(&env);
     trig::install(&env);
     pairs::install(&env);
     vectors::install(&env);
-    io::install(&env);
+    io::install(&env, stdin_port, stdout_port);
     env
 }
 

--- a/libsrs/src/interpretor/evaluator/natives/io.rs
+++ b/libsrs/src/interpretor/evaluator/natives/io.rs
@@ -1,8 +1,13 @@
+use std::cell::RefCell;
 use std::rc::Rc;
 
-use crate::types::core::{Env, Native, SrsValue};
+use crate::types::core::{Env, Native, PortData, SrsValue};
 
-pub(super) fn install(env: &Rc<Env>) {
+pub(super) fn install(
+    env: &Rc<Env>,
+    stdin_port: Rc<RefCell<PortData>>,
+    stdout_port: Rc<RefCell<PortData>>,
+) {
     env.define(
         "display".to_string(),
         SrsValue::Native(Native {
@@ -29,6 +34,20 @@ pub(super) fn install(env: &Rc<Env>) {
         SrsValue::Native(Native {
             name: "eof-object?",
             func: Rc::new(native_eof_object_p),
+        }),
+    );
+    env.define(
+        "current-input-port".to_string(),
+        SrsValue::Native(Native {
+            name: "current-input-port",
+            func: Rc::new(move |args| native_current_input_port(args, &stdin_port)),
+        }),
+    );
+    env.define(
+        "current-output-port".to_string(),
+        SrsValue::Native(Native {
+            name: "current-output-port",
+            func: Rc::new(move |args| native_current_output_port(args, &stdout_port)),
         }),
     );
 }
@@ -83,5 +102,27 @@ fn native_eof_object_p(args: &[SrsValue]) -> Result<SrsValue, String> {
         [value] => Ok(SrsValue::Boolean(matches!(value, SrsValue::Eof))),
         [] => Err("not enough arguments to eof-object?".to_string()),
         _ => Err("too many arguments to eof-object?".to_string()),
+    }
+}
+
+/// `(current-input-port)`: returns the singleton standard input port.
+fn native_current_input_port(
+    args: &[SrsValue],
+    stdin_port: &Rc<RefCell<PortData>>,
+) -> Result<SrsValue, String> {
+    match args {
+        [] => Ok(SrsValue::Port(stdin_port.clone())),
+        _ => Err("too many arguments to current-input-port".to_string()),
+    }
+}
+
+/// `(current-output-port)`: returns the singleton standard output port.
+fn native_current_output_port(
+    args: &[SrsValue],
+    stdout_port: &Rc<RefCell<PortData>>,
+) -> Result<SrsValue, String> {
+    match args {
+        [] => Ok(SrsValue::Port(stdout_port.clone())),
+        _ => Err("too many arguments to current-output-port".to_string()),
     }
 }

--- a/libsrs/src/interpretor/evaluator/natives/pairs.rs
+++ b/libsrs/src/interpretor/evaluator/natives/pairs.rs
@@ -56,6 +56,13 @@ pub(super) fn install(env: &Rc<Env>) {
             func: Rc::new(native_is_null),
         }),
     );
+    env.define(
+        "eq?".to_string(),
+        SrsValue::Native(Native {
+            name: "eq?",
+            func: Rc::new(native_eq_p),
+        }),
+    );
 }
 
 /// `(cons car cdr)`: allocates a fresh mutable pair.
@@ -149,5 +156,40 @@ fn native_is_null(args: &[SrsValue]) -> Result<SrsValue, String> {
         [obj] => Ok(SrsValue::Boolean(matches!(obj, SrsValue::Nil))),
         [] => Err("not enough arguments to null?".to_string()),
         _ => Err("too many arguments to null?".to_string()),
+    }
+}
+
+/// `(eq? obj1 obj2)`: returns `#t` if `obj1` and `obj2` are the same
+/// object (R5RS section 6.1). For mutable/Rc-wrapped values this uses
+/// pointer identity; atomic values are compared by value.
+fn native_eq_p(args: &[SrsValue]) -> Result<SrsValue, String> {
+    match args {
+        [a, b] => Ok(SrsValue::Boolean(srs_value_eq(a, b))),
+        [] | [_] => Err("not enough arguments to eq?".to_string()),
+        _ => Err("too many arguments to eq?".to_string()),
+    }
+}
+
+fn srs_value_eq(a: &SrsValue, b: &SrsValue) -> bool {
+    match (a, b) {
+        (SrsValue::Integer(x), SrsValue::Integer(y)) => x == y,
+        (SrsValue::Float(x), SrsValue::Float(y)) => x == y,
+        (SrsValue::Rational(n1, d1), SrsValue::Rational(n2, d2)) => n1 == n2 && d1 == d2,
+        (SrsValue::Boolean(x), SrsValue::Boolean(y)) => x == y,
+        (SrsValue::Character(x), SrsValue::Character(y)) => x == y,
+        (SrsValue::Symbol(x), SrsValue::Symbol(y)) => x == y,
+        (SrsValue::Nil, SrsValue::Nil) => true,
+        (SrsValue::Unspecified, SrsValue::Unspecified) => true,
+        (SrsValue::Eof, SrsValue::Eof) => true,
+        (SrsValue::String(s1), SrsValue::String(s2)) => Rc::ptr_eq(s1, s2),
+        (SrsValue::Pair(p1), SrsValue::Pair(p2)) => Rc::ptr_eq(p1, p2),
+        (SrsValue::Vector(v1), SrsValue::Vector(v2)) => Rc::ptr_eq(v1, v2),
+        (SrsValue::Procedure(l1), SrsValue::Procedure(l2)) => Rc::ptr_eq(l1, l2),
+        (SrsValue::Promise(p1), SrsValue::Promise(p2)) => Rc::ptr_eq(p1, p2),
+        (SrsValue::Port(p1), SrsValue::Port(p2)) => Rc::ptr_eq(p1, p2),
+        (SrsValue::Native(n1), SrsValue::Native(n2)) => {
+            n1.name == n2.name && Rc::ptr_eq(&n1.func, &n2.func)
+        }
+        _ => false,
     }
 }

--- a/libsrs/tests/r5rs/io_tests.rs
+++ b/libsrs/tests/r5rs/io_tests.rs
@@ -33,3 +33,51 @@ fn eof_object_p_returns_false_for_non_eof_values() {
         SrsValue::Boolean(false)
     ));
 }
+
+#[test]
+fn current_input_port_returns_port_value() {
+    assert!(matches!(
+        eval_src("(current-input-port)"),
+        SrsValue::Port(_)
+    ));
+}
+
+#[test]
+fn current_output_port_returns_port_value() {
+    assert!(matches!(
+        eval_src("(current-output-port)"),
+        SrsValue::Port(_)
+    ));
+}
+
+#[test]
+fn current_input_port_is_singleton() {
+    assert!(matches!(
+        eval_src("(eq? (current-input-port) (current-input-port))"),
+        SrsValue::Boolean(true)
+    ));
+}
+
+#[test]
+fn current_output_port_is_singleton() {
+    assert!(matches!(
+        eval_src("(eq? (current-output-port) (current-output-port))"),
+        SrsValue::Boolean(true)
+    ));
+}
+
+#[test]
+fn current_input_port_binds_internal_variable() {
+    assert!(matches!(
+        eval_src("(eq? (current-input-port) *current-input-port*)"),
+        SrsValue::Boolean(true)
+    ));
+}
+
+#[test]
+fn current_output_port_binds_internal_variable() {
+    assert!(matches!(
+        eval_src("(eq? (current-output-port) *current-output-port*)"),
+        SrsValue::Boolean(true)
+    ));
+}


### PR DESCRIPTION
Closes #51.

- Builds stdin/stdout ports once in `global_env()` and binds them as `*current-input-port*` / `*current-output-port*`.
- Adds `current-input-port` and `current-output-port` primitives returning the same `Rc` each call.
- Adds `eq?` so acceptance checks like `(eq? (current-input-port) (current-input-port))` work (pointer identity for Rc-wrapped values, value equality for atomic values).
- Adds unit tests for both ports and singleton property.