### PR TITLE
I/O ports (4/7): read-char et peek-char sur stdin

### DIFF
--- a/libsrs/src/interpretor/evaluator/natives/io.rs
+++ b/libsrs/src/interpretor/evaluator/natives/io.rs
@@ -8,6 +8,10 @@ pub(super) fn install(
     stdin_port: Rc<RefCell<PortData>>,
     stdout_port: Rc<RefCell<PortData>>,
 ) {
+    let stdin_for_current = stdin_port.clone();
+    let stdin_for_read = stdin_port.clone();
+    let stdin_for_peek = stdin_port;
+
     env.define(
         "display".to_string(),
         SrsValue::Native(Native {
@@ -40,7 +44,7 @@ pub(super) fn install(
         "current-input-port".to_string(),
         SrsValue::Native(Native {
             name: "current-input-port",
-            func: Rc::new(move |args| native_current_input_port(args, &stdin_port)),
+            func: Rc::new(move |args| native_current_input_port(args, &stdin_for_current)),
         }),
     );
     env.define(
@@ -48,6 +52,20 @@ pub(super) fn install(
         SrsValue::Native(Native {
             name: "current-output-port",
             func: Rc::new(move |args| native_current_output_port(args, &stdout_port)),
+        }),
+    );
+    env.define(
+        "read-char".to_string(),
+        SrsValue::Native(Native {
+            name: "read-char",
+            func: Rc::new(move |args| native_read_char(args, &stdin_for_read)),
+        }),
+    );
+    env.define(
+        "peek-char".to_string(),
+        SrsValue::Native(Native {
+            name: "peek-char",
+            func: Rc::new(move |args| native_peek_char(args, &stdin_for_peek)),
         }),
     );
 }
@@ -125,4 +143,40 @@ fn native_current_output_port(
         [] => Ok(SrsValue::Port(stdout_port.clone())),
         _ => Err("too many arguments to current-output-port".to_string()),
     }
+}
+
+/// Resolves the port argument for character-input procedures.
+/// Accepts either zero arguments (use the default stdin port) or one
+/// argument that must be an input port.
+fn input_port_from_args(
+    proc_name: &str,
+    args: &[SrsValue],
+    default: &Rc<RefCell<PortData>>,
+) -> Result<Rc<RefCell<PortData>>, String> {
+    match args {
+        [] => Ok(default.clone()),
+        [SrsValue::Port(port)] => Ok(port.clone()),
+        [_] => Err(format!("wrong type: expected input port to {}", proc_name)),
+        _ => Err(format!("too many arguments to {}", proc_name)),
+    }
+}
+
+/// `(read-char [port])`: reads and consumes one character from the input
+/// port, returning `eof-object` at end of file.
+fn native_read_char(
+    args: &[SrsValue],
+    stdin_port: &Rc<RefCell<PortData>>,
+) -> Result<SrsValue, String> {
+    let port = input_port_from_args("read-char", args, stdin_port)?;
+    port.borrow_mut().read_char()
+}
+
+/// `(peek-char [port])`: reads one character from the input port without
+/// consuming it, returning `eof-object` at end of file.
+fn native_peek_char(
+    args: &[SrsValue],
+    stdin_port: &Rc<RefCell<PortData>>,
+) -> Result<SrsValue, String> {
+    let port = input_port_from_args("peek-char", args, stdin_port)?;
+    port.borrow_mut().peek_char()
 }

--- a/libsrs/src/types/core.rs
+++ b/libsrs/src/types/core.rs
@@ -1,7 +1,7 @@
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::fmt;
-use std::io::{BufReader, Stdin};
+use std::io::{BufReader, Read, Stdin};
 use std::rc::Rc;
 
 /// Lexical environment: variable bindings + optional parent scope.
@@ -221,12 +221,88 @@ impl SrsValue {
 impl PortData {
     /// Builds a port reading from standard input.
     pub fn stdin() -> Self {
-        PortData::InputStdin(BufReader::new(std::io::stdin()))
+        PortData::InputStdin {
+            reader: BufReader::new(std::io::stdin()),
+            peeked: None,
+        }
     }
 
     /// Builds a port writing to standard output.
     pub fn stdout() -> Self {
         PortData::OutputStdout
+    }
+
+    /// Reads and consumes one character from the input port, returning
+    /// [`SrsValue::Eof`] at end of file.
+    pub fn read_char(&mut self) -> Result<SrsValue, String> {
+        match self {
+            PortData::InputStdin { reader, peeked } => {
+                if let Some(c) = peeked.take() {
+                    return Ok(SrsValue::Character(c));
+                }
+                read_char_from_reader(reader)
+                    .map(|opt| opt.map(SrsValue::Character).unwrap_or(SrsValue::Eof))
+            }
+            PortData::OutputStdout => Err("read-char: not an input port".to_string()),
+        }
+    }
+
+    /// Reads one character from the input port without consuming it,
+    /// returning [`SrsValue::Eof`] at end of file.
+    pub fn peek_char(&mut self) -> Result<SrsValue, String> {
+        match self {
+            PortData::InputStdin { reader, peeked } => {
+                if let Some(c) = *peeked {
+                    return Ok(SrsValue::Character(c));
+                }
+                let c = read_char_from_reader(reader)?;
+                if let Some(ch) = c {
+                    *peeked = Some(ch);
+                }
+                Ok(c.map(SrsValue::Character).unwrap_or(SrsValue::Eof))
+            }
+            PortData::OutputStdout => Err("peek-char: not an input port".to_string()),
+        }
+    }
+}
+
+fn read_char_from_reader<R: Read>(reader: &mut R) -> Result<Option<char>, String> {
+    use std::io::ErrorKind;
+
+    let mut first = [0u8; 1];
+    if let Err(e) = reader.read_exact(&mut first) {
+        return if e.kind() == ErrorKind::UnexpectedEof {
+            Ok(None)
+        } else {
+            Err(format!("read-char: {}", e))
+        };
+    }
+
+    let len = utf8_char_len(first[0]);
+    let mut buf = [0u8; 4];
+    buf[0] = first[0];
+    if len > 1 {
+        reader
+            .read_exact(&mut buf[1..len])
+            .map_err(|e| format!("read-char: {}", e))?;
+    }
+
+    std::str::from_utf8(&buf[..len])
+        .map_err(|_| "read-char: invalid UTF-8".to_string())
+        .map(|s| s.chars().next())
+}
+
+fn utf8_char_len(first_byte: u8) -> usize {
+    if first_byte & 0b1000_0000 == 0 {
+        1
+    } else if first_byte & 0b1110_0000 == 0b1100_0000 {
+        2
+    } else if first_byte & 0b1111_0000 == 0b1110_0000 {
+        3
+    } else if first_byte & 0b1111_1000 == 0b1111_0000 {
+        4
+    } else {
+        1
     }
 }
 
@@ -250,13 +326,17 @@ pub enum PromiseState {
 /// Runtime data behind an [`SrsValue::Port`].
 #[derive(Debug)]
 pub enum PortData {
-    InputStdin(BufReader<Stdin>),
+    InputStdin {
+        reader: BufReader<Stdin>,
+        peeked: Option<char>,
+    },
     OutputStdout,
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::Cursor;
 
     #[test]
     fn display_repr_of_string_has_no_quotes() {
@@ -302,5 +382,40 @@ mod tests {
         let value = SrsValue::Port(Rc::new(RefCell::new(PortData::stdout())));
         assert_eq!(value.to_string(), "#<port>");
         assert_eq!(value.display_repr(), "#<port>");
+    }
+
+    #[test]
+    fn utf8_char_len_detects_sequence_lengths() {
+        assert_eq!(utf8_char_len(b'a'), 1);
+        assert_eq!(utf8_char_len(0xc2), 2);
+        assert_eq!(utf8_char_len(0xe2), 3);
+        assert_eq!(utf8_char_len(0xf0), 4);
+    }
+
+    #[test]
+    fn read_char_from_reader_reads_ascii_and_multibyte_chars() {
+        let mut cursor = Cursor::new("aé€");
+        assert_eq!(read_char_from_reader(&mut cursor).unwrap(), Some('a'));
+        assert_eq!(read_char_from_reader(&mut cursor).unwrap(), Some('é'));
+        assert_eq!(read_char_from_reader(&mut cursor).unwrap(), Some('€'));
+    }
+
+    #[test]
+    fn read_char_from_reader_returns_eof_on_empty_input() {
+        let mut cursor = Cursor::new("");
+        assert_eq!(read_char_from_reader(&mut cursor).unwrap(), None);
+    }
+
+    #[test]
+    fn read_char_from_reader_returns_error_on_invalid_utf8() {
+        let mut cursor = Cursor::new(vec![0xff]);
+        assert!(read_char_from_reader(&mut cursor).is_err());
+    }
+
+    #[test]
+    fn output_port_read_char_errors() {
+        let mut port = PortData::stdout();
+        assert!(port.read_char().is_err());
+        assert!(port.peek_char().is_err());
     }
 }

--- a/libsrs/tests/r5rs/io_tests.rs
+++ b/libsrs/tests/r5rs/io_tests.rs
@@ -3,14 +3,18 @@ use libsrs::interpretor::lexical_analyzer::get_lexemes;
 use libsrs::interpretor::reader::read_all;
 use libsrs::types::core::SrsValue;
 
-fn eval_src(scm: &str) -> SrsValue {
+fn eval_all(scm: &str) -> Result<SrsValue, String> {
     let values = read_all(get_lexemes(scm).unwrap()).unwrap();
     let env = global_env();
     let mut result = SrsValue::Unspecified;
     for value in &values {
-        result = eval(value, &env).unwrap();
+        result = eval(value, &env).map_err(|e| e.to_string())?;
     }
-    result
+    Ok(result)
+}
+
+fn eval_src(scm: &str) -> SrsValue {
+    eval_all(scm).unwrap()
 }
 
 #[test]
@@ -80,4 +84,83 @@ fn current_output_port_binds_internal_variable() {
         eval_src("(eq? (current-output-port) *current-output-port*)"),
         SrsValue::Boolean(true)
     ));
+}
+
+#[test]
+fn read_char_rejects_non_port_argument() {
+    assert!(eval_all("(read-char 42)").is_err());
+}
+
+#[test]
+fn read_char_rejects_too_many_arguments() {
+    assert!(eval_all("(read-char (current-input-port) 1)").is_err());
+}
+
+#[test]
+fn peek_char_rejects_non_port_argument() {
+    assert!(eval_all("(peek-char 42)").is_err());
+}
+
+#[test]
+fn peek_char_rejects_too_many_arguments() {
+    assert!(eval_all("(peek-char (current-input-port) 1)").is_err());
+}
+
+#[test]
+fn read_char_rejects_output_port() {
+    assert!(eval_all("(read-char (current-output-port))").is_err());
+    assert!(eval_all("(peek-char (current-output-port))").is_err());
+}
+
+#[test]
+#[ignore = "requires data on stdin; run with `echo -n 'x' | cargo test -- --ignored`"]
+fn read_char_on_current_input_port_returns_character_or_eof() {
+    // This test exercises the real standard input port. String ports
+    // (step 6) will allow a fully automated test.
+    let values = read_all(get_lexemes("(read-char)").unwrap()).unwrap();
+    let env = global_env();
+    let result = eval(&values[0], &env).unwrap();
+    assert!(
+        matches!(result, SrsValue::Character(_) | SrsValue::Eof),
+        "expected #<char> or #<eof>, got {}",
+        result
+    );
+}
+
+#[test]
+#[ignore = "requires data on stdin; run with `echo -n 'x' | cargo test -- --ignored`"]
+fn peek_char_on_current_input_port_returns_character_or_eof() {
+    // See read_char_on_current_input_port_returns_character_or_eof.
+    let values = read_all(get_lexemes("(peek-char)").unwrap()).unwrap();
+    let env = global_env();
+    let result = eval(&values[0], &env).unwrap();
+    assert!(
+        matches!(result, SrsValue::Character(_) | SrsValue::Eof),
+        "expected #<char> or #<eof>, got {}",
+        result
+    );
+}
+
+#[test]
+#[ignore = "requires data on stdin; run twice with a single-char input: peek then read should match"]
+fn peek_then_read_return_same_character() {
+    let env = global_env();
+    let first = eval(
+        &read_all(get_lexemes("(peek-char)").unwrap()).unwrap()[0],
+        &env,
+    )
+    .unwrap();
+    let second = eval(
+        &read_all(get_lexemes("(read-char)").unwrap()).unwrap()[0],
+        &env,
+    )
+    .unwrap();
+    match (&first, &second) {
+        (SrsValue::Character(a), SrsValue::Character(b)) if a == b => {}
+        (SrsValue::Eof, SrsValue::Eof) => {}
+        _ => panic!(
+            "expected peek and read to return the same character, got {} and {}",
+            first, second
+        ),
+    }
 }


### PR DESCRIPTION
Implémente `read-char` et `peek-char` pour les ports d'entrée standard.

- Ajout d'un buffer de 1 caractère dans `PortData::InputStdin`.
- Décodage UTF-8 sur 1-4 octets via BufReader, retour de l'objet EOF en fin de flux.
- Port optionnel, défaut `current-input-port`.
- Gestion des erreurs I/O/wrong-type/trop d'arguments.
- Tests unitaires ASCII/multi-byte/EOF + tests interactifs en attente des string ports (step 6).

Closes #52