### PR TITLE
feat(io): implement read-line and char-ready?

### DIFF
--- a/libsrs/src/interpretor/evaluator/natives/io.rs
+++ b/libsrs/src/interpretor/evaluator/natives/io.rs
@@ -10,7 +10,9 @@ pub(super) fn install(
 ) {
     let stdin_for_current = stdin_port.clone();
     let stdin_for_read = stdin_port.clone();
-    let stdin_for_peek = stdin_port;
+    let stdin_for_peek = stdin_port.clone();
+    let stdin_for_read_line = stdin_port.clone();
+    let stdin_for_char_ready = stdin_port;
 
     env.define(
         "display".to_string(),
@@ -66,6 +68,20 @@ pub(super) fn install(
         SrsValue::Native(Native {
             name: "peek-char",
             func: Rc::new(move |args| native_peek_char(args, &stdin_for_peek)),
+        }),
+    );
+    env.define(
+        "read-line".to_string(),
+        SrsValue::Native(Native {
+            name: "read-line",
+            func: Rc::new(move |args| native_read_line(args, &stdin_for_read_line)),
+        }),
+    );
+    env.define(
+        "char-ready?".to_string(),
+        SrsValue::Native(Native {
+            name: "char-ready?",
+            func: Rc::new(move |args| native_char_ready_p(args, &stdin_for_char_ready)),
         }),
     );
 }
@@ -155,7 +171,8 @@ fn input_port_from_args(
 ) -> Result<Rc<RefCell<PortData>>, String> {
     match args {
         [] => Ok(default.clone()),
-        [SrsValue::Port(port)] => Ok(port.clone()),
+        [SrsValue::Port(port)] if port.borrow().is_input_port() => Ok(port.clone()),
+        [SrsValue::Port(_)] => Err(format!("{}: not an input port", proc_name)),
         [_] => Err(format!("wrong type: expected input port to {}", proc_name)),
         _ => Err(format!("too many arguments to {}", proc_name)),
     }
@@ -179,4 +196,30 @@ fn native_peek_char(
 ) -> Result<SrsValue, String> {
     let port = input_port_from_args("peek-char", args, stdin_port)?;
     port.borrow_mut().peek_char()
+}
+
+/// `(read-line [port])`: reads characters from the input port until a
+/// newline or end of file, returning the accumulated string. Returns
+/// `eof-object` if no characters could be read before EOF.
+fn native_read_line(
+    args: &[SrsValue],
+    stdin_port: &Rc<RefCell<PortData>>,
+) -> Result<SrsValue, String> {
+    let port = input_port_from_args("read-line", args, stdin_port)?;
+    port.borrow_mut().read_line()
+}
+
+/// `(char-ready? [port])`: returns `#t` if a character is ready on the
+/// input port, `#f` otherwise.
+///
+/// NOTE: Correct implementation for stdin is non-trivial because the
+/// underlying `BufReader` may block on real terminal input. Until string
+/// ports (step 6) or non-blocking input handling is available, this
+/// procedure conservatively returns `#t` for input ports.
+fn native_char_ready_p(
+    args: &[SrsValue],
+    stdin_port: &Rc<RefCell<PortData>>,
+) -> Result<SrsValue, String> {
+    let port = input_port_from_args("char-ready?", args, stdin_port)?;
+    Ok(SrsValue::Boolean(port.borrow().is_input_port()))
 }

--- a/libsrs/src/types/core.rs
+++ b/libsrs/src/types/core.rs
@@ -1,7 +1,7 @@
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::fmt;
-use std::io::{BufReader, Read, Stdin};
+use std::io::{BufReader, Read};
 use std::rc::Rc;
 
 /// Lexical environment: variable bindings + optional parent scope.
@@ -222,7 +222,7 @@ impl PortData {
     /// Builds a port reading from standard input.
     pub fn stdin() -> Self {
         PortData::InputStdin {
-            reader: BufReader::new(std::io::stdin()),
+            reader: BufReader::new(Box::new(std::io::stdin())),
             peeked: None,
         }
     }
@@ -230,6 +230,16 @@ impl PortData {
     /// Builds a port writing to standard output.
     pub fn stdout() -> Self {
         PortData::OutputStdout
+    }
+
+    /// Builds an input port from a byte slice, for unit tests.
+    #[cfg(test)]
+    pub fn test_input(data: &'static [u8]) -> Self {
+        use std::io::Cursor;
+        PortData::InputStdin {
+            reader: BufReader::new(Box::new(Cursor::new(data))),
+            peeked: None,
+        }
     }
 
     /// Reads and consumes one character from the input port, returning
@@ -262,6 +272,40 @@ impl PortData {
                 Ok(c.map(SrsValue::Character).unwrap_or(SrsValue::Eof))
             }
             PortData::OutputStdout => Err("peek-char: not an input port".to_string()),
+        }
+    }
+
+    /// Returns `true` if this port can be used for input.
+    pub fn is_input_port(&self) -> bool {
+        matches!(self, PortData::InputStdin { .. })
+    }
+
+    /// Reads characters from the input port until a newline (excluded) or
+    /// end of file, returning the accumulated string. If the first read
+    /// yields EOF, returns [`SrsValue::Eof`].
+    pub fn read_line(&mut self) -> Result<SrsValue, String> {
+        match self {
+            PortData::InputStdin { reader, peeked } => {
+                let mut buf = String::new();
+                loop {
+                    let c = if let Some(c) = peeked.take() {
+                        Ok(Some(c))
+                    } else {
+                        read_char_from_reader(reader)
+                    };
+                    match c? {
+                        Some('\n') => return Ok(SrsValue::String(Rc::new(RefCell::new(buf)))),
+                        Some(ch) => buf.push(ch),
+                        None => {
+                            if buf.is_empty() {
+                                return Ok(SrsValue::Eof);
+                            }
+                            return Ok(SrsValue::String(Rc::new(RefCell::new(buf))));
+                        }
+                    }
+                }
+            }
+            PortData::OutputStdout => Err("read-line: not an input port".to_string()),
         }
     }
 }
@@ -324,13 +368,24 @@ pub enum PromiseState {
 }
 
 /// Runtime data behind an [`SrsValue::Port`].
-#[derive(Debug)]
 pub enum PortData {
     InputStdin {
-        reader: BufReader<Stdin>,
+        reader: BufReader<Box<dyn Read>>,
         peeked: Option<char>,
     },
     OutputStdout,
+}
+
+impl fmt::Debug for PortData {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            PortData::InputStdin { peeked, .. } => f
+                .debug_struct("InputStdin")
+                .field("peeked", peeked)
+                .finish(),
+            PortData::OutputStdout => write!(f, "OutputStdout"),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -417,5 +472,29 @@ mod tests {
         let mut port = PortData::stdout();
         assert!(port.read_char().is_err());
         assert!(port.peek_char().is_err());
+    }
+
+    #[test]
+    fn read_line_returns_strings_until_eof() {
+        let mut port = PortData::test_input(b"abc\ndef");
+        assert!(
+            matches!(port.read_line().unwrap(), SrsValue::String(s) if s.borrow().as_str() == "abc")
+        );
+        assert!(
+            matches!(port.read_line().unwrap(), SrsValue::String(s) if s.borrow().as_str() == "def")
+        );
+        assert!(matches!(port.read_line().unwrap(), SrsValue::Eof));
+    }
+
+    #[test]
+    fn read_line_returns_eof_on_empty_input() {
+        let mut port = PortData::test_input(b"");
+        assert!(matches!(port.read_line().unwrap(), SrsValue::Eof));
+    }
+
+    #[test]
+    fn output_port_read_line_errors() {
+        let mut port = PortData::stdout();
+        assert!(port.read_line().is_err());
     }
 }

--- a/libsrs/tests/r5rs/io_tests.rs
+++ b/libsrs/tests/r5rs/io_tests.rs
@@ -164,3 +164,59 @@ fn peek_then_read_return_same_character() {
         ),
     }
 }
+
+#[test]
+fn read_line_rejects_non_port_argument() {
+    assert!(eval_all("(read-line 42)").is_err());
+}
+
+#[test]
+fn read_line_rejects_too_many_arguments() {
+    assert!(eval_all("(read-line (current-input-port) 1)").is_err());
+}
+
+#[test]
+fn read_line_rejects_output_port() {
+    assert!(eval_all("(read-line (current-output-port))").is_err());
+}
+
+#[test]
+fn char_ready_rejects_non_port_argument() {
+    assert!(eval_all("(char-ready? 42)").is_err());
+}
+
+#[test]
+fn char_ready_rejects_too_many_arguments() {
+    assert!(eval_all("(char-ready? (current-input-port) 1)").is_err());
+}
+
+#[test]
+fn char_ready_rejects_output_port() {
+    assert!(eval_all("(char-ready? (current-output-port))").is_err());
+}
+
+#[test]
+fn char_ready_without_args_returns_boolean() {
+    assert!(matches!(eval_src("(char-ready?)"), SrsValue::Boolean(true)));
+}
+
+#[test]
+fn char_ready_with_input_port_returns_boolean() {
+    assert!(matches!(
+        eval_src("(char-ready? (current-input-port))"),
+        SrsValue::Boolean(true)
+    ));
+}
+
+#[test]
+#[ignore = "requires data on stdin; run with `echo -n 'x' | cargo test -- --ignored`"]
+fn read_line_on_current_input_port_returns_string_or_eof() {
+    let values = read_all(get_lexemes("(read-line)").unwrap()).unwrap();
+    let env = global_env();
+    let result = eval(&values[0], &env).unwrap();
+    assert!(
+        matches!(result, SrsValue::String(_) | SrsValue::Eof),
+        "expected string or eof, got {}",
+        result
+    );
+}


### PR DESCRIPTION
Closes #53

- Implement `read-line` (0/1 arg, default `current-input-port`): reads until newline or EOF, returns string or eof-object.
- Implement `char-ready?` (0/1 arg): returns #t for input ports; documented stub limitation for real blocking stdin.
- Reject output ports for character-input procedures.
- Switch `PortData` inner reader to `Box<dyn Read>` to enable test input ports.
- Add unit and integration tests.

Verified: `cargo fmt`, `cargo clippy --all-targets`, `cargo test` green.