### PR TITLE
feat(io): implement string ports

### DIFF
--- a/libsrs/src/interpretor/evaluator/natives/io.rs
+++ b/libsrs/src/interpretor/evaluator/natives/io.rs
@@ -84,6 +84,34 @@ pub(super) fn install(
             func: Rc::new(move |args| native_char_ready_p(args, &stdin_for_char_ready)),
         }),
     );
+    env.define(
+        "open-input-string".to_string(),
+        SrsValue::Native(Native {
+            name: "open-input-string",
+            func: Rc::new(native_open_input_string),
+        }),
+    );
+    env.define(
+        "open-output-string".to_string(),
+        SrsValue::Native(Native {
+            name: "open-output-string",
+            func: Rc::new(native_open_output_string),
+        }),
+    );
+    env.define(
+        "get-output-string".to_string(),
+        SrsValue::Native(Native {
+            name: "get-output-string",
+            func: Rc::new(native_get_output_string),
+        }),
+    );
+    env.define(
+        "write-char".to_string(),
+        SrsValue::Native(Native {
+            name: "write-char",
+            func: Rc::new(native_write_char),
+        }),
+    );
 }
 
 /// `(display value)`: writes `value` to standard output using its
@@ -178,6 +206,24 @@ fn input_port_from_args(
     }
 }
 
+/// Resolves the port argument for output procedures.
+/// Accepts either zero arguments (use the default stdout port) or one
+/// argument that must be an output port.
+#[allow(dead_code)]
+fn output_port_from_args(
+    proc_name: &str,
+    args: &[SrsValue],
+    default: &Rc<RefCell<PortData>>,
+) -> Result<Rc<RefCell<PortData>>, String> {
+    match args {
+        [] => Ok(default.clone()),
+        [SrsValue::Port(port)] if port.borrow().is_output_port() => Ok(port.clone()),
+        [SrsValue::Port(_)] => Err(format!("{}: not an output port", proc_name)),
+        [_] => Err(format!("wrong type: expected output port to {}", proc_name)),
+        _ => Err(format!("too many arguments to {}", proc_name)),
+    }
+}
+
 /// `(read-char [port])`: reads and consumes one character from the input
 /// port, returning `eof-object` at end of file.
 fn native_read_char(
@@ -213,13 +259,76 @@ fn native_read_line(
 /// input port, `#f` otherwise.
 ///
 /// NOTE: Correct implementation for stdin is non-trivial because the
-/// underlying `BufReader` may block on real terminal input. Until string
-/// ports (step 6) or non-blocking input handling is available, this
-/// procedure conservatively returns `#t` for input ports.
+/// underlying `BufReader` may block on real terminal input. String ports
+/// report availability based on remaining characters.
 fn native_char_ready_p(
     args: &[SrsValue],
     stdin_port: &Rc<RefCell<PortData>>,
 ) -> Result<SrsValue, String> {
     let port = input_port_from_args("char-ready?", args, stdin_port)?;
-    Ok(SrsValue::Boolean(port.borrow().is_input_port()))
+    let ready = match &*port.borrow() {
+        PortData::InputStdin { .. } => true,
+        PortData::InputString(chars, pos) => *pos < chars.len(),
+        _ => false,
+    };
+    Ok(SrsValue::Boolean(ready))
+}
+
+/// `(open-input-string s)`: returns a new input port reading from string `s`.
+fn native_open_input_string(args: &[SrsValue]) -> Result<SrsValue, String> {
+    match args {
+        [SrsValue::String(s)] => Ok(SrsValue::Port(Rc::new(RefCell::new(
+            PortData::input_string(s.borrow().clone()),
+        )))),
+        [SrsValue::Symbol(_)] => Err("open-input-string: expected string".to_string()),
+        [] => Err("not enough arguments to open-input-string".to_string()),
+        [_] => Err("wrong type: expected string".to_string()),
+        _ => Err("too many arguments to open-input-string".to_string()),
+    }
+}
+
+/// `(open-output-string)`: returns a new output port accumulating into a
+/// string buffer.
+fn native_open_output_string(args: &[SrsValue]) -> Result<SrsValue, String> {
+    match args {
+        [] => Ok(SrsValue::Port(Rc::new(RefCell::new(
+            PortData::output_string(),
+        )))),
+        _ => Err("too many arguments to open-output-string".to_string()),
+    }
+}
+
+/// `(get-output-string port)`: returns the contents accumulated in an
+/// output-string port as a new Scheme string.
+fn native_get_output_string(args: &[SrsValue]) -> Result<SrsValue, String> {
+    match args {
+        [SrsValue::Port(port)] => {
+            let contents = port.borrow().get_output_string()?;
+            Ok(SrsValue::String(Rc::new(RefCell::new(contents))))
+        }
+        [] => Err("not enough arguments to get-output-string".to_string()),
+        _ => Err("wrong type: expected output-string port".to_string()),
+    }
+}
+
+/// `(write-char char [port])`: writes `char` to the output port. Uses the
+/// current output port when no port is provided.
+fn native_write_char(args: &[SrsValue]) -> Result<SrsValue, String> {
+    match args {
+        [SrsValue::Character(c)] => {
+            use std::io::Write;
+            print!("{}", c);
+            std::io::stdout()
+                .flush()
+                .map_err(|e| format!("write-char: {}", e))?;
+            Ok(SrsValue::Unspecified)
+        }
+        [SrsValue::Character(c), SrsValue::Port(port)] => {
+            port.borrow_mut().write_char(*c)?;
+            Ok(SrsValue::Unspecified)
+        }
+        [] | [_] => Err("not enough arguments to write-char".to_string()),
+        [_, _] => Err("wrong type: expected character and output port".to_string()),
+        _ => Err("too many arguments to write-char".to_string()),
+    }
 }

--- a/libsrs/src/types/core.rs
+++ b/libsrs/src/types/core.rs
@@ -232,6 +232,16 @@ impl PortData {
         PortData::OutputStdout
     }
 
+    /// Builds an input port from a string.
+    pub fn input_string(s: impl Into<String>) -> Self {
+        PortData::InputString(s.into().chars().collect::<Vec<_>>(), 0)
+    }
+
+    /// Builds an output port accumulating into a string.
+    pub fn output_string() -> Self {
+        PortData::OutputString(String::new())
+    }
+
     /// Builds an input port from a byte slice, for unit tests.
     #[cfg(test)]
     pub fn test_input(data: &'static [u8]) -> Self {
@@ -253,7 +263,17 @@ impl PortData {
                 read_char_from_reader(reader)
                     .map(|opt| opt.map(SrsValue::Character).unwrap_or(SrsValue::Eof))
             }
-            PortData::OutputStdout => Err("read-char: not an input port".to_string()),
+            PortData::InputString(chars, pos) => {
+                if let Some(&c) = chars.get(*pos) {
+                    *pos += 1;
+                    Ok(SrsValue::Character(c))
+                } else {
+                    Ok(SrsValue::Eof)
+                }
+            }
+            PortData::OutputStdout | PortData::OutputString(_) => {
+                Err("read-char: not an input port".to_string())
+            }
         }
     }
 
@@ -271,13 +291,30 @@ impl PortData {
                 }
                 Ok(c.map(SrsValue::Character).unwrap_or(SrsValue::Eof))
             }
-            PortData::OutputStdout => Err("peek-char: not an input port".to_string()),
+            PortData::InputString(chars, pos) => {
+                if let Some(&c) = chars.get(*pos) {
+                    Ok(SrsValue::Character(c))
+                } else {
+                    Ok(SrsValue::Eof)
+                }
+            }
+            PortData::OutputStdout | PortData::OutputString(_) => {
+                Err("peek-char: not an input port".to_string())
+            }
         }
     }
 
     /// Returns `true` if this port can be used for input.
     pub fn is_input_port(&self) -> bool {
-        matches!(self, PortData::InputStdin { .. })
+        matches!(
+            self,
+            PortData::InputStdin { .. } | PortData::InputString(..)
+        )
+    }
+
+    /// Returns `true` if this port can be used for output.
+    pub fn is_output_port(&self) -> bool {
+        matches!(self, PortData::OutputStdout | PortData::OutputString(_))
     }
 
     /// Reads characters from the input port until a newline (excluded) or
@@ -305,7 +342,50 @@ impl PortData {
                     }
                 }
             }
-            PortData::OutputStdout => Err("read-line: not an input port".to_string()),
+            PortData::InputString(chars, pos) => {
+                let mut buf = String::new();
+                while let Some(&c) = chars.get(*pos) {
+                    *pos += 1;
+                    if c == '\n' {
+                        return Ok(SrsValue::String(Rc::new(RefCell::new(buf))));
+                    }
+                    buf.push(c);
+                }
+                if buf.is_empty() {
+                    Ok(SrsValue::Eof)
+                } else {
+                    Ok(SrsValue::String(Rc::new(RefCell::new(buf))))
+                }
+            }
+            PortData::OutputStdout | PortData::OutputString(_) => {
+                Err("read-line: not an input port".to_string())
+            }
+        }
+    }
+
+    /// Writes a character to the output port.
+    pub fn write_char(&mut self, c: char) -> Result<(), String> {
+        match self {
+            PortData::OutputString(buf) => {
+                buf.push(c);
+                Ok(())
+            }
+            PortData::OutputStdout => {
+                use std::io::Write;
+                print!("{}", c);
+                std::io::stdout()
+                    .flush()
+                    .map_err(|e| format!("write-char: {}", e))
+            }
+            _ => Err("write-char: not an output port".to_string()),
+        }
+    }
+
+    /// Returns the contents accumulated in an output-string port.
+    pub fn get_output_string(&self) -> Result<String, String> {
+        match self {
+            PortData::OutputString(buf) => Ok(buf.clone()),
+            _ => Err("get-output-string: not an output-string port".to_string()),
         }
     }
 }
@@ -369,11 +449,17 @@ pub enum PromiseState {
 
 /// Runtime data behind an [`SrsValue::Port`].
 pub enum PortData {
+    /// Standard input backed by an opaque reader.
     InputStdin {
         reader: BufReader<Box<dyn Read>>,
         peeked: Option<char>,
     },
+    /// Standard output.
     OutputStdout,
+    /// Input port reading characters from a string using a byte index.
+    InputString(Vec<char>, usize),
+    /// Output port accumulating characters into a string.
+    OutputString(String),
 }
 
 impl fmt::Debug for PortData {
@@ -384,6 +470,12 @@ impl fmt::Debug for PortData {
                 .field("peeked", peeked)
                 .finish(),
             PortData::OutputStdout => write!(f, "OutputStdout"),
+            PortData::InputString(chars, pos) => f
+                .debug_tuple("InputString")
+                .field(&chars.iter().collect::<String>())
+                .field(pos)
+                .finish(),
+            PortData::OutputString(buf) => f.debug_tuple("OutputString").field(buf).finish(),
         }
     }
 }
@@ -496,5 +588,59 @@ mod tests {
     fn output_port_read_line_errors() {
         let mut port = PortData::stdout();
         assert!(port.read_line().is_err());
+    }
+
+    #[test]
+    fn input_string_port_reads_chars_and_eof() {
+        let mut port = PortData::input_string("ab");
+        assert!(matches!(
+            port.read_char().unwrap(),
+            SrsValue::Character('a')
+        ));
+        assert!(matches!(
+            port.peek_char().unwrap(),
+            SrsValue::Character('b')
+        ));
+        assert!(matches!(
+            port.peek_char().unwrap(),
+            SrsValue::Character('b')
+        ));
+        assert!(matches!(
+            port.read_char().unwrap(),
+            SrsValue::Character('b')
+        ));
+        assert!(matches!(port.read_char().unwrap(), SrsValue::Eof));
+    }
+
+    #[test]
+    fn input_string_port_read_line_with_newlines() {
+        let mut port = PortData::input_string("abc\ndef");
+        let first = port.read_line().unwrap();
+        assert!(matches!(first, SrsValue::String(s) if s.borrow().as_str() == "abc"));
+        let second = port.read_line().unwrap();
+        assert!(matches!(second, SrsValue::String(s) if s.borrow().as_str() == "def"));
+        assert!(matches!(port.read_line().unwrap(), SrsValue::Eof));
+    }
+
+    #[test]
+    fn input_string_port_read_line_eof_on_empty() {
+        let mut port = PortData::input_string("");
+        assert!(matches!(port.read_line().unwrap(), SrsValue::Eof));
+    }
+
+    #[test]
+    fn output_string_port_accumulates_chars() {
+        let mut port = PortData::output_string();
+        port.write_char('x').unwrap();
+        port.write_char('y').unwrap();
+        assert_eq!(port.get_output_string().unwrap(), "xy");
+    }
+
+    #[test]
+    fn get_output_string_rejects_non_output_string_port() {
+        let port = PortData::stdout();
+        assert!(port.get_output_string().is_err());
+        let port = PortData::input_string("x");
+        assert!(port.get_output_string().is_err());
     }
 }

--- a/libsrs/tests/r5rs/io_tests.rs
+++ b/libsrs/tests/r5rs/io_tests.rs
@@ -13,6 +13,27 @@ fn eval_all(scm: &str) -> Result<SrsValue, String> {
     Ok(result)
 }
 
+fn string_value(value: SrsValue) -> String {
+    match value {
+        SrsValue::String(s) => s.borrow().clone(),
+        other => panic!("expected string, got {}", other),
+    }
+}
+
+fn char_value(value: SrsValue) -> char {
+    match value {
+        SrsValue::Character(c) => c,
+        other => panic!("expected character, got {}", other),
+    }
+}
+
+fn boolean_value(value: SrsValue) -> bool {
+    match value {
+        SrsValue::Boolean(b) => b,
+        other => panic!("expected boolean, got {}", other),
+    }
+}
+
 fn eval_src(scm: &str) -> SrsValue {
     eval_all(scm).unwrap()
 }
@@ -113,56 +134,39 @@ fn read_char_rejects_output_port() {
 }
 
 #[test]
-#[ignore = "requires data on stdin; run with `echo -n 'x' | cargo test -- --ignored`"]
-fn read_char_on_current_input_port_returns_character_or_eof() {
-    // This test exercises the real standard input port. String ports
-    // (step 6) will allow a fully automated test.
-    let values = read_all(get_lexemes("(read-char)").unwrap()).unwrap();
-    let env = global_env();
-    let result = eval(&values[0], &env).unwrap();
-    assert!(
-        matches!(result, SrsValue::Character(_) | SrsValue::Eof),
-        "expected #<char> or #<eof>, got {}",
-        result
+fn read_char_on_string_port_returns_character_or_eof() {
+    assert_eq!(
+        char_value(eval_src("(read-char (open-input-string \"x\"))")),
+        'x'
     );
+    assert!(matches!(
+        eval_src("(read-char (open-input-string \"\"))"),
+        SrsValue::Eof
+    ));
 }
 
 #[test]
-#[ignore = "requires data on stdin; run with `echo -n 'x' | cargo test -- --ignored`"]
-fn peek_char_on_current_input_port_returns_character_or_eof() {
-    // See read_char_on_current_input_port_returns_character_or_eof.
-    let values = read_all(get_lexemes("(peek-char)").unwrap()).unwrap();
-    let env = global_env();
-    let result = eval(&values[0], &env).unwrap();
-    assert!(
-        matches!(result, SrsValue::Character(_) | SrsValue::Eof),
-        "expected #<char> or #<eof>, got {}",
-        result
+fn peek_char_on_string_port_returns_character_or_eof() {
+    assert_eq!(
+        char_value(eval_src("(peek-char (open-input-string \"x\"))")),
+        'x'
     );
+    assert!(matches!(
+        eval_src("(peek-char (open-input-string \"\"))"),
+        SrsValue::Eof
+    ));
 }
 
 #[test]
-#[ignore = "requires data on stdin; run twice with a single-char input: peek then read should match"]
-fn peek_then_read_return_same_character() {
-    let env = global_env();
-    let first = eval(
-        &read_all(get_lexemes("(peek-char)").unwrap()).unwrap()[0],
-        &env,
-    )
-    .unwrap();
-    let second = eval(
-        &read_all(get_lexemes("(read-char)").unwrap()).unwrap()[0],
-        &env,
-    )
-    .unwrap();
-    match (&first, &second) {
-        (SrsValue::Character(a), SrsValue::Character(b)) if a == b => {}
-        (SrsValue::Eof, SrsValue::Eof) => {}
-        _ => panic!(
-            "expected peek and read to return the same character, got {} and {}",
-            first, second
-        ),
-    }
+fn peek_then_read_return_same_character_on_string_port() {
+    assert_eq!(
+        eval_src("(let ((p (open-input-string \"x\"))) (peek-char p))").to_string(),
+        "#\\x"
+    );
+    assert_eq!(
+        eval_src("(let ((p (open-input-string \"ab\"))) (peek-char p) (read-char p))").to_string(),
+        "#\\a"
+    );
 }
 
 #[test]
@@ -209,14 +213,65 @@ fn char_ready_with_input_port_returns_boolean() {
 }
 
 #[test]
-#[ignore = "requires data on stdin; run with `echo -n 'x' | cargo test -- --ignored`"]
-fn read_line_on_current_input_port_returns_string_or_eof() {
-    let values = read_all(get_lexemes("(read-line)").unwrap()).unwrap();
-    let env = global_env();
-    let result = eval(&values[0], &env).unwrap();
-    assert!(
-        matches!(result, SrsValue::String(_) | SrsValue::Eof),
-        "expected string or eof, got {}",
-        result
+fn read_line_on_string_port_returns_string_or_eof() {
+    assert_eq!(
+        string_value(eval_src("(read-line (open-input-string \"abc\ndef\"))")),
+        "abc"
     );
+    assert!(matches!(
+        eval_src("(read-line (open-input-string \"\"))"),
+        SrsValue::Eof
+    ));
+}
+
+#[test]
+fn open_input_string_creates_input_port() {
+    assert!(eval_all("(open-input-string \"hello\")").is_ok());
+}
+
+#[test]
+fn open_input_string_requires_string() {
+    assert!(eval_all("(open-input-string 42)").is_err());
+    assert!(eval_all("(open-input-string)").is_err());
+    assert!(eval_all("(open-input-string \"a\" \"b\")").is_err());
+}
+
+#[test]
+fn open_output_string_creates_output_port() {
+    assert!(eval_all("(open-output-string)").is_ok());
+    assert!(eval_all("(open-output-string 1)").is_err());
+}
+
+#[test]
+fn get_output_string_returns_accumulated_content() {
+    let result =
+        eval_src("(let ((p (open-output-string))) (write-char #\\x p) (get-output-string p))");
+    assert_eq!(string_value(result), "x");
+}
+
+#[test]
+fn get_output_string_requires_output_string_port() {
+    assert!(eval_all("(get-output-string)").is_err());
+    assert!(eval_all("(get-output-string (current-output-port))").is_err());
+    assert!(eval_all("(get-output-string (open-input-string \"x\"))").is_err());
+}
+
+#[test]
+fn write_char_requires_character() {
+    assert!(eval_all("(write-char \"x\")").is_err());
+}
+
+#[test]
+fn write_char_rejects_input_port() {
+    assert!(eval_all("(write-char #\\x (open-input-string \"x\"))").is_err());
+}
+
+#[test]
+fn char_ready_on_string_port_reflects_remaining_data() {
+    assert!(boolean_value(eval_src(
+        "(char-ready? (open-input-string \"x\"))"
+    )));
+    assert!(!boolean_value(eval_src(
+        "(let ((p (open-input-string \"\"))) (char-ready? p))"
+    )));
 }


### PR DESCRIPTION
Closes #54.

- Add `PortData::InputString` and `PortData::OutputString` variants.
- Implement `open-input-string`, `open-output-string`, `get-output-string` and `write-char` primitives.
- Extend `read-char`, `peek-char`, `read-line` and `char-ready?` to support string input ports.
- Replace stdin-dependent ignored tests with deterministic string-port tests.

Verified with `cargo fmt`, `cargo clippy --all-targets -- -D warnings` and `cargo test`.