### PR TITLE
feat(io): route display/newline/write-char through Port

### DIFF
--- a/libsrs/doc/r5rs_subset.md
+++ b/libsrs/doc/r5rs_subset.md
@@ -69,10 +69,12 @@ Absents : `vector-map`, `vector-for-each`, `vector-copy`.
 
 ### Entrées/sorties (`natives/io.rs`)
 
-`display` `newline`
+`display` `newline` `write-char` `write-string` `read-char` `peek-char`
+`read-line` `char-ready?` `eof-object` `eof-object?` `current-input-port`
+`current-output-port` `open-input-string` `open-output-string`
+`get-output-string`
 
-Absents : `write`, `read`, `read-char`, `write-char`, ports,
-`open-input-file`/`open-output-file`, etc.
+Absents : `write`, `read`, `open-input-file`/`open-output-file`, etc.
 
 ### Totalement absent
 
@@ -100,9 +102,9 @@ Absents : `write`, `read`, `read-char`, `write-char`, ports,
 - `Unspecified`, `Eof`
 - `Procedure` (lambda), `Native`
 - `Promise` — type défini mais mort (aucune primitive ne l'utilise)
+- `Port` — port d'entrée/sortie (stdin/stdout, chaînes en mémoire)
 
-Pas de nombres complexes, pas de type Port explicite (I/O directe via
-`print!`/`println!` côté Rust).
+Pas de nombres complexes.
 
 ## Autres écarts vs R5RS
 
@@ -121,3 +123,7 @@ Pas de nombres complexes, pas de type Port explicite (I/O directe via
 - `procedure_tests.rs` : `lambda`, application, `let`, `let*`
 - `vector_tests.rs` : `vector`, `vector?`, `make-vector`, `vector-length`,
   `vector-ref`, `vector-set!`, `vector->list`, `list->vector`, `vector-fill!`
+- `io_tests.rs` : `display`, `newline`, `write-char`, `write-string`, ports
+  de chaînes (`open-input-string`, `open-output-string`, `get-output-string`),
+  `read-char`, `peek-char`, `read-line`, `char-ready?`, `eof-object`,
+  `current-input-port`, `current-output-port`

--- a/libsrs/src/interpretor/evaluator/natives/io.rs
+++ b/libsrs/src/interpretor/evaluator/natives/io.rs
@@ -1,6 +1,7 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 
+use super::index_from;
 use crate::types::core::{Env, Native, PortData, SrsValue};
 
 pub(super) fn install(
@@ -14,18 +15,23 @@ pub(super) fn install(
     let stdin_for_read_line = stdin_port.clone();
     let stdin_for_char_ready = stdin_port;
 
+    let stdout_for_display = stdout_port.clone();
+    let stdout_for_newline = stdout_port.clone();
+    let stdout_for_write_char = stdout_port.clone();
+    let stdout_for_write_string = stdout_port.clone();
+
     env.define(
         "display".to_string(),
         SrsValue::Native(Native {
             name: "display",
-            func: Rc::new(native_display),
+            func: Rc::new(move |args| native_display(args, &stdout_for_display)),
         }),
     );
     env.define(
         "newline".to_string(),
         SrsValue::Native(Native {
             name: "newline",
-            func: Rc::new(native_newline),
+            func: Rc::new(move |args| native_newline(args, &stdout_for_newline)),
         }),
     );
     env.define(
@@ -109,41 +115,87 @@ pub(super) fn install(
         "write-char".to_string(),
         SrsValue::Native(Native {
             name: "write-char",
-            func: Rc::new(native_write_char),
+            func: Rc::new(move |args| native_write_char(args, &stdout_for_write_char)),
+        }),
+    );
+    env.define(
+        "write-string".to_string(),
+        SrsValue::Native(Native {
+            name: "write-string",
+            func: Rc::new(move |args| native_write_string(args, &stdout_for_write_string)),
         }),
     );
 }
 
-/// `(display value)`: writes `value` to standard output using its
+/// `(display value [port])`: writes `value` to the output port using its
 /// human-readable representation (no quotes around strings, characters
-/// printed as themselves). Returns [`SrsValue::Unspecified`].
-fn native_display(args: &[SrsValue]) -> Result<SrsValue, String> {
-    match args {
-        [value] => {
+/// printed as themselves). Uses the current output port when `port` is
+/// omitted. Returns [`SrsValue::Unspecified`].
+fn native_display(
+    args: &[SrsValue],
+    stdout_port: &Rc<RefCell<PortData>>,
+) -> Result<SrsValue, String> {
+    let (value, port) = match args {
+        [value] => (value, stdout_port.clone()),
+        [value, SrsValue::Port(port)] => {
+            if !port.borrow().is_output_port() {
+                return Err("display: not an output port".to_string());
+            }
+            (value, port.clone())
+        }
+        [] => return Err("not enough arguments to display".to_string()),
+        [_, _] => return Err("wrong type: expected output port".to_string()),
+        _ => return Err("too many arguments to display".to_string()),
+    };
+    let repr = value.display_repr();
+    let mut port = port.borrow_mut();
+    match &mut *port {
+        PortData::OutputString(buf) => {
+            buf.push_str(&repr);
+            Ok(SrsValue::Unspecified)
+        }
+        PortData::OutputStdout => {
             use std::io::Write;
-            print!("{}", value.display_repr());
+            print!("{}", repr);
             std::io::stdout()
                 .flush()
                 .map_err(|e| format!("display: {}", e))?;
             Ok(SrsValue::Unspecified)
         }
-        [] => Err("not enough arguments to display".to_string()),
-        _ => Err("too many arguments to display".to_string()),
+        _ => Err("display: not an output port".to_string()),
     }
 }
 
-/// `(newline)`: writes a line break to standard output. Returns
+/// `(newline [port])`: writes a line break to the output port. Uses the
+/// current output port when `port` is omitted. Returns
 /// [`SrsValue::Unspecified`].
-fn native_newline(args: &[SrsValue]) -> Result<SrsValue, String> {
+fn native_newline(
+    args: &[SrsValue],
+    stdout_port: &Rc<RefCell<PortData>>,
+) -> Result<SrsValue, String> {
     match args {
         [] => {
-            use std::io::Write;
-            println!();
-            std::io::stdout()
-                .flush()
-                .map_err(|e| format!("newline: {}", e))?;
+            let mut port = stdout_port.borrow_mut();
+            port.write_char('\n').map_err(|e| {
+                if e.starts_with("write-char:") {
+                    e.replace("write-char:", "newline:")
+                } else {
+                    format!("newline: {}", e)
+                }
+            })?;
             Ok(SrsValue::Unspecified)
         }
+        [SrsValue::Port(port)] => {
+            port.borrow_mut().write_char('\n').map_err(|e| {
+                if e.starts_with("write-char:") {
+                    e.replace("write-char:", "newline:")
+                } else {
+                    format!("newline: {}", e)
+                }
+            })?;
+            Ok(SrsValue::Unspecified)
+        }
+        [_] => Err("wrong type: expected output port".to_string()),
         _ => Err("too many arguments to newline".to_string()),
     }
 }
@@ -313,22 +365,57 @@ fn native_get_output_string(args: &[SrsValue]) -> Result<SrsValue, String> {
 
 /// `(write-char char [port])`: writes `char` to the output port. Uses the
 /// current output port when no port is provided.
-fn native_write_char(args: &[SrsValue]) -> Result<SrsValue, String> {
+fn native_write_char(
+    args: &[SrsValue],
+    stdout_port: &Rc<RefCell<PortData>>,
+) -> Result<SrsValue, String> {
     match args {
-        [SrsValue::Character(c)] => {
-            use std::io::Write;
-            print!("{}", c);
-            std::io::stdout()
-                .flush()
-                .map_err(|e| format!("write-char: {}", e))?;
-            Ok(SrsValue::Unspecified)
-        }
-        [SrsValue::Character(c), SrsValue::Port(port)] => {
-            port.borrow_mut().write_char(*c)?;
-            Ok(SrsValue::Unspecified)
-        }
+        [SrsValue::Character(c)] => stdout_port
+            .borrow_mut()
+            .write_char(*c)
+            .map(|_| SrsValue::Unspecified),
+        [SrsValue::Character(c), SrsValue::Port(port)] => port
+            .borrow_mut()
+            .write_char(*c)
+            .map(|_| SrsValue::Unspecified),
         [] | [_] => Err("not enough arguments to write-char".to_string()),
         [_, _] => Err("wrong type: expected character and output port".to_string()),
         _ => Err("too many arguments to write-char".to_string()),
     }
+}
+
+/// `(write-string string [port [start [end]]])`: writes the characters of
+/// `string` to the output port. Uses the current output port when `port` is
+/// omitted. Returns [`SrsValue::Unspecified`].
+fn native_write_string(
+    args: &[SrsValue],
+    stdout_port: &Rc<RefCell<PortData>>,
+) -> Result<SrsValue, String> {
+    if args.is_empty() {
+        return Err("not enough arguments to write-string".to_string());
+    }
+    if args.len() > 4 {
+        return Err("too many arguments to write-string".to_string());
+    }
+    let s = match &args[0] {
+        SrsValue::String(s) => s.borrow().clone(),
+        _ => return Err("wrong type: expected string".to_string()),
+    };
+    let port = match args.get(1) {
+        None => stdout_port.clone(),
+        Some(SrsValue::Port(port)) if port.borrow().is_output_port() => port.clone(),
+        Some(SrsValue::Port(_)) => return Err("write-string: not an output port".to_string()),
+        Some(_) => return Err("wrong type: expected output port".to_string()),
+    };
+    let start = match args.get(2) {
+        Some(v) => Some(index_from(v, "write-string")?),
+        None => None,
+    };
+    let end = match args.get(3) {
+        Some(v) => Some(index_from(v, "write-string")?),
+        None => None,
+    };
+    port.borrow_mut()
+        .write_string(&s, start, end)
+        .map(|_| SrsValue::Unspecified)
 }

--- a/libsrs/src/interpretor/evaluator/tests.rs
+++ b/libsrs/src/interpretor/evaluator/tests.rs
@@ -541,6 +541,17 @@ fn newline_too_many_args_fails() {
 }
 
 #[test]
+fn write_string_requires_string() {
+    assert!(eval_src("(write-string 42)").is_err());
+    assert!(eval_src("(write-string)").is_err());
+}
+
+#[test]
+fn write_string_with_too_many_args_fails() {
+    assert!(eval_src("(let ((p (open-output-string))) (write-string \"a\" p 0 1 2))").is_err());
+}
+
+#[test]
 fn cons_creates_a_pair() {
     assert!(matches!(ok("(cons 1 2)"), SrsValue::Pair(_)));
 }

--- a/libsrs/src/types/core.rs
+++ b/libsrs/src/types/core.rs
@@ -381,6 +381,36 @@ impl PortData {
         }
     }
 
+    /// Writes a string to the output port, optionally bounded by `start` and
+    /// `end` character offsets.
+    pub fn write_string(
+        &mut self,
+        s: &str,
+        start: Option<usize>,
+        end: Option<usize>,
+    ) -> Result<(), String> {
+        let start = start.unwrap_or(0);
+        let end = end.unwrap_or(s.chars().count());
+        if start > end {
+            return Err("write-string: start greater than end".to_string());
+        }
+        let slice: String = s.chars().skip(start).take(end - start).collect();
+        match self {
+            PortData::OutputString(buf) => {
+                buf.push_str(&slice);
+                Ok(())
+            }
+            PortData::OutputStdout => {
+                use std::io::Write;
+                print!("{}", slice);
+                std::io::stdout()
+                    .flush()
+                    .map_err(|e| format!("write-string: {}", e))
+            }
+            _ => Err("write-string: not an output port".to_string()),
+        }
+    }
+
     /// Returns the contents accumulated in an output-string port.
     pub fn get_output_string(&self) -> Result<String, String> {
         match self {
@@ -634,6 +664,20 @@ mod tests {
         port.write_char('x').unwrap();
         port.write_char('y').unwrap();
         assert_eq!(port.get_output_string().unwrap(), "xy");
+    }
+
+    #[test]
+    fn output_string_port_accumulates_substring() {
+        let mut port = PortData::output_string();
+        port.write_string("hello", Some(1), Some(4)).unwrap();
+        assert_eq!(port.get_output_string().unwrap(), "ell");
+    }
+
+    #[test]
+    fn output_string_port_write_string_without_bounds_writes_all() {
+        let mut port = PortData::output_string();
+        port.write_string("hi", None, None).unwrap();
+        assert_eq!(port.get_output_string().unwrap(), "hi");
     }
 
     #[test]

--- a/libsrs/tests/r5rs/io_tests.rs
+++ b/libsrs/tests/r5rs/io_tests.rs
@@ -275,3 +275,75 @@ fn char_ready_on_string_port_reflects_remaining_data() {
         "(let ((p (open-input-string \"\"))) (char-ready? p))"
     )));
 }
+
+#[test]
+fn display_writes_to_output_string_port() {
+    let result =
+        eval_src("(let ((p (open-output-string))) (display \"hi\" p) (get-output-string p))");
+    assert_eq!(string_value(result), "hi");
+}
+
+#[test]
+fn display_rejects_input_port() {
+    assert!(eval_all("(display \"x\" (open-input-string \"x\"))").is_err());
+}
+
+#[test]
+fn display_accepts_current_output_port() {
+    assert!(eval_all("(display \"x\" (current-output-port))").is_ok());
+}
+
+#[test]
+fn newline_writes_to_output_string_port() {
+    let result = eval_src("(let ((p (open-output-string))) (newline p) (get-output-string p))");
+    assert_eq!(string_value(result), "\n");
+}
+
+#[test]
+fn newline_rejects_input_port() {
+    assert!(eval_all("(newline (open-input-string \"x\"))").is_err());
+}
+
+#[test]
+fn write_char_uses_current_output_port_by_default() {
+    assert!(eval_all("(write-char #\\a)").is_ok());
+}
+
+#[test]
+fn write_char_writes_to_output_string_port() {
+    let result =
+        eval_src("(let ((p (open-output-string))) (write-char #\\a p) (get-output-string p))");
+    assert_eq!(string_value(result), "a");
+}
+
+#[test]
+fn write_string_writes_to_output_string_port() {
+    let result = eval_src(
+        "(let ((p (open-output-string))) (write-string \"hello\" p) (get-output-string p))",
+    );
+    assert_eq!(string_value(result), "hello");
+}
+
+#[test]
+fn write_string_supports_start_end_bounds() {
+    let result = eval_src(
+        "(let ((p (open-output-string))) (write-string \"hello\" p 1 4) (get-output-string p))",
+    );
+    assert_eq!(string_value(result), "ell");
+}
+
+#[test]
+fn write_string_rejects_input_port() {
+    assert!(eval_all("(write-string \"x\" (open-input-string \"x\"))").is_err());
+}
+
+#[test]
+fn write_string_requires_string() {
+    assert!(eval_all("(write-string 42)").is_err());
+    assert!(eval_all("(write-string)").is_err());
+}
+
+#[test]
+fn write_string_with_too_many_args_fails() {
+    assert!(eval_all("(let ((p (open-output-string))) (write-string \"a\" p 0 1 2))").is_err());
+}


### PR DESCRIPTION
Implémente #55.

- `display`, `newline`, `write-char` acceptent un port optionnel et écrivent via `PortData`.
- Ajoute `write-string` avec bornes optionnelles `start` / `end`.
- Ajoute `PortData::write_string`.
- Met à jour `r5rs_subset.md` et les tests d'I/O.

Closes #55