### PR TITLE
feat(load): resolve bare library names to ~/.config/srs/libs

### DIFF
--- a/libsrs/doc/r5rs_subset.md
+++ b/libsrs/doc/r5rs_subset.md
@@ -18,7 +18,7 @@ Dispatch dans `interpretor/evaluator/special_forms.rs::eval_combination`.
 | `if` | ✅ | |
 | `quote` | ✅ | |
 | `quasiquote` | ✅ | `unquote`, `unquote-splicing`, imbrication |
-| `load` | ⚠️ extension | chargement de fichier, non standard R5RS |
+| `load` | ⚠️ extension | chargement de fichier, non standard R5RS. Les chemins contenant un `/` ou se terminant par `.scm` sont utilisés tels quels ; un nom nu (ex: `(load "csv")`) est cherché dans `~/.config/srs/libs/<nom>.scm` |
 
 ### Non implémentées
 

--- a/libsrs/src/interpretor/evaluator.rs
+++ b/libsrs/src/interpretor/evaluator.rs
@@ -9,6 +9,9 @@ mod special_forms;
 mod tests;
 mod util;
 
+#[cfg(test)]
+pub(crate) use special_forms::resolve_load_path_with_home;
+
 pub use natives::global_env;
 
 /// The specific reason an [`EvalError`] was raised.

--- a/libsrs/src/interpretor/evaluator/special_forms.rs
+++ b/libsrs/src/interpretor/evaluator/special_forms.rs
@@ -293,6 +293,10 @@ fn eval_quasiquote(args: &[SrsValue], env: &Rc<Env>) -> Result<SrsValue, EvalErr
 /// expressions from it, and evaluates them in sequence in the current
 /// environment `env`. Returns the value of the last expression, or
 /// [`SrsValue::Unspecified`] if the file is empty.
+///
+/// If `<filename>` contains a `/` or already ends with `.scm`, it is used as
+/// a literal path. Otherwise it is treated as a bare library name and
+/// resolved to `~/.config/srs/libs/<name>.scm`.
 fn eval_load(args: &[SrsValue], env: &Rc<Env>) -> Result<SrsValue, EvalError> {
     let path_expr = match args {
         [path_expr] => path_expr,
@@ -306,8 +310,14 @@ fn eval_load(args: &[SrsValue], env: &Rc<Env>) -> Result<SrsValue, EvalError> {
         _ => return err(EvalErrorKind::WrongType),
     };
 
-    let source = std::fs::read_to_string(&path).map_err(|e| EvalError {
-        kind: EvalErrorKind::Native(format!("load: could not read {}: {}", path, e)),
+    let resolved = resolve_load_path(&path);
+
+    let source = std::fs::read_to_string(&resolved).map_err(|e| EvalError {
+        kind: EvalErrorKind::Native(format!(
+            "load: could not read {}: {}",
+            resolved.display(),
+            e
+        )),
     })?;
 
     let lexemes =
@@ -323,6 +333,29 @@ fn eval_load(args: &[SrsValue], env: &Rc<Env>) -> Result<SrsValue, EvalError> {
         result = eval(expr, env)?;
     }
     Ok(result)
+}
+
+/// Resolves a `load` argument into an actual filesystem path.
+///
+/// Literal paths (`/path/file.scm`, `./file.scm`, `foo/bar.scm`) are returned
+/// unchanged. Bare library names (`csv`) are mapped to
+/// `~/.config/srs/libs/<name>.scm`.
+fn resolve_load_path(path: &str) -> std::path::PathBuf {
+    resolve_load_path_with_home(path, std::env::var("HOME").ok().as_deref())
+}
+
+pub(crate) fn resolve_load_path_with_home(path: &str, home: Option<&str>) -> std::path::PathBuf {
+    if path.contains('/') || path.ends_with(".scm") {
+        std::path::PathBuf::from(path)
+    } else if let Some(home) = home {
+        std::path::PathBuf::from(home)
+            .join(".config")
+            .join("srs")
+            .join("libs")
+            .join(format!("{}.scm", path))
+    } else {
+        std::path::PathBuf::from(path)
+    }
 }
 
 /// Recursively expands a quasiquoted template at the given nesting `depth`.

--- a/libsrs/src/interpretor/evaluator/tests.rs
+++ b/libsrs/src/interpretor/evaluator/tests.rs
@@ -1,6 +1,10 @@
+use std::sync::Mutex;
+
 use super::*;
 use crate::interpretor::lexical_analyzer::get_lexemes;
 use crate::interpretor::reader::read_all;
+
+static HOME_LOCK: Mutex<()> = Mutex::new(());
 
 fn eval_src(src: &str) -> Result<SrsValue, EvalError> {
     let values = read_all(get_lexemes(src).unwrap()).unwrap();
@@ -860,4 +864,83 @@ fn load_too_many_args_fails() {
 #[test]
 fn load_non_string_path_fails() {
     assert!(eval_src("(load 42)").is_err());
+}
+
+#[test]
+fn load_bare_name_resolves_to_config_lib_dir() {
+    let resolved = resolve_load_path_with_home("csv", Some("/home/jean"));
+    assert_eq!(
+        resolved,
+        std::path::PathBuf::from("/home/jean/.config/srs/libs/csv.scm")
+    );
+}
+
+#[test]
+fn load_bare_name_missing_home_falls_back_to_literal() {
+    let resolved = resolve_load_path_with_home("csv", None);
+    assert_eq!(resolved, std::path::PathBuf::from("csv"));
+}
+
+#[test]
+fn load_explicit_path_with_slash_unresolved() {
+    let resolved = resolve_load_path_with_home("./csv.scm", Some("/home/jean"));
+    assert_eq!(resolved, std::path::PathBuf::from("./csv.scm"));
+}
+
+#[test]
+fn load_explicit_path_ending_in_scm_unresolved() {
+    let resolved = resolve_load_path_with_home("/path/to/csv", Some("/home/jean"));
+    assert_eq!(resolved, std::path::PathBuf::from("/path/to/csv"));
+}
+
+#[test]
+fn load_bare_name_integration_uses_config_lib_dir() {
+    let _guard = HOME_LOCK.lock().unwrap();
+
+    let home = std::env::temp_dir().join(format!("srs_test_home_{}", std::process::id()));
+    let libs = home.join(".config").join("srs").join("libs");
+    std::fs::create_dir_all(&libs).unwrap();
+
+    let lib_path = libs.join("csv.scm");
+    {
+        use std::io::Write;
+        let mut file = std::fs::File::create(&lib_path).unwrap();
+        file.write_all(b"(define answer 42)").unwrap();
+    }
+
+    let original_home = std::env::var("HOME").ok();
+    let result = unsafe {
+        std::env::set_var("HOME", &home);
+        let result = eval_src("(load \"csv\") answer");
+        if let Some(h) = original_home {
+            std::env::set_var("HOME", h);
+        } else {
+            std::env::remove_var("HOME");
+        }
+        result
+    };
+    std::fs::remove_dir_all(&home).ok();
+
+    assert!(matches!(result.unwrap(), SrsValue::Integer(42)));
+}
+
+#[test]
+fn load_bare_name_missing_file_error_mentions_resolved_path() {
+    let _guard = HOME_LOCK.lock().unwrap();
+
+    let original_home = std::env::var("HOME").ok();
+    let err = unsafe {
+        std::env::set_var("HOME", "/nonexistent/home/dir/for/srs/tests");
+        let err = eval_src("(load \"nonexistent_lib\")").unwrap_err();
+        if let Some(h) = original_home {
+            std::env::set_var("HOME", h);
+        } else {
+            std::env::remove_var("HOME");
+        }
+        err
+    };
+
+    let msg = format!("{}", err);
+    assert!(msg.contains("nonexistent_lib"));
+    assert!(msg.contains(".config/srs/libs"));
 }


### PR DESCRIPTION
- Paths with `/` or ending in `.scm` stay literal
- Bare names (e.g. `(load "csv")`) resolve to `~/.config/srs/libs/<name>.scm`
- Missing file error now reports the resolved path
- Tests added for resolution rules and integration
- Docs updated

Closes #64