### PR TITLE
feat(natives): add string primitives

### DIFF
--- a/libsrs/Cargo.toml
+++ b/libsrs/Cargo.toml
@@ -26,3 +26,7 @@ path = "tests/r5rs/vector_tests.rs"
 [[test]]
 name = "r5rs_io"
 path = "tests/r5rs/io_tests.rs"
+
+[[test]]
+name = "r5rs_string"
+path = "tests/r5rs/string_tests.rs"

--- a/libsrs/doc/r5rs_subset.md
+++ b/libsrs/doc/r5rs_subset.md
@@ -71,6 +71,14 @@ Absents : `pair?`, `list?`, `list`, `set-car!`, `set-cdr!`, `append`,
 
 Absents : `vector-map`, `vector-for-each`, `vector-copy`.
 
+### Chaînes (`natives/strings.rs`)
+
+`string?` `string-length` `string-ref` `string=?` `substring` `string-append`
+`list->string`
+
+Absents : `string-set!`, `string->list`, `string-ci=?` et comparaisons
+insensibles à la casse, `make-string`, `string-copy`, `string-fill!`.
+
 ### Entrées/sorties (`natives/io.rs`)
 
 `display` `newline` `write-char` `write-string` `read-char` `peek-char`
@@ -82,8 +90,8 @@ Absents : `write`, `read`, `open-input-file`/`open-output-file`, etc.
 
 ### Totalement absent
 
-- Strings : `string?`, `string-length`, `string-ref`, `string-set!`,
-  `substring`, `string-append`, `string->list`, `list->string`, `string=?`, ...
+- Strings : `string-set!`, `string->list`, `string-ci=?` et apparentes,
+  `make-string`, `string-copy`, `string-fill!`
 - Chars : `char?`, `char->integer`, `integer->char`, `char-alphabetic?`, ...
 - Symboles : `symbol?`, `symbol->string`, `string->symbol`
 - Booléens : `boolean?`
@@ -131,6 +139,8 @@ Pas de nombres complexes.
 - `procedure_tests.rs` : `lambda`, application, `let`, `let*`
 - `vector_tests.rs` : `vector`, `vector?`, `make-vector`, `vector-length`,
   `vector-ref`, `vector-set!`, `vector->list`, `list->vector`, `vector-fill!`
+- `string_tests.rs` : `string?`, `string-length`, `string-ref`, `string=?`,
+  `substring`, `string-append`, `list->string`
 - `io_tests.rs` : `display`, `newline`, `write-char`, `write-string`, ports
   de chaînes (`open-input-string`, `open-output-string`, `get-output-string`),
   `read-char`, `peek-char`, `read-line`, `char-ready?`, `eof-object`,

--- a/libsrs/src/interpretor/evaluator/natives.rs
+++ b/libsrs/src/interpretor/evaluator/natives.rs
@@ -6,6 +6,7 @@ use crate::types::core::{Env, PortData, SrsValue};
 mod arithmetic;
 mod io;
 mod pairs;
+mod strings;
 mod trig;
 mod vectors;
 
@@ -27,6 +28,7 @@ pub fn global_env() -> Rc<Env> {
     trig::install(&env);
     pairs::install(&env);
     vectors::install(&env);
+    strings::install(&env);
     io::install(&env, stdin_port, stdout_port);
     env
 }

--- a/libsrs/src/interpretor/evaluator/natives/strings.rs
+++ b/libsrs/src/interpretor/evaluator/natives/strings.rs
@@ -1,0 +1,175 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use crate::types::core::{Env, Native, SrsValue};
+
+use super::super::util::list_to_vec;
+use super::index_from;
+
+pub(super) fn install(env: &Rc<Env>) {
+    env.define(
+        "string?".to_string(),
+        SrsValue::Native(Native {
+            name: "string?",
+            func: Rc::new(native_string_p),
+        }),
+    );
+    env.define(
+        "string-length".to_string(),
+        SrsValue::Native(Native {
+            name: "string-length",
+            func: Rc::new(native_string_length),
+        }),
+    );
+    env.define(
+        "string-ref".to_string(),
+        SrsValue::Native(Native {
+            name: "string-ref",
+            func: Rc::new(native_string_ref),
+        }),
+    );
+    env.define(
+        "string=?".to_string(),
+        SrsValue::Native(Native {
+            name: "string=?",
+            func: Rc::new(native_string_eq),
+        }),
+    );
+    env.define(
+        "substring".to_string(),
+        SrsValue::Native(Native {
+            name: "substring",
+            func: Rc::new(native_substring),
+        }),
+    );
+    env.define(
+        "string-append".to_string(),
+        SrsValue::Native(Native {
+            name: "string-append",
+            func: Rc::new(native_string_append),
+        }),
+    );
+    env.define(
+        "list->string".to_string(),
+        SrsValue::Native(Native {
+            name: "list->string",
+            func: Rc::new(native_list_to_string),
+        }),
+    );
+}
+
+/// `(string? obj)`: returns `#t` if `obj` is a string, `#f` otherwise.
+fn native_string_p(args: &[SrsValue]) -> Result<SrsValue, String> {
+    match args {
+        [only] => Ok(SrsValue::Boolean(matches!(only, SrsValue::String(_)))),
+        [] => Err("not enough arguments to string?".to_string()),
+        _ => Err("too many arguments to string?".to_string()),
+    }
+}
+
+/// `(string-length string)`: returns the number of characters in `string`.
+fn native_string_length(args: &[SrsValue]) -> Result<SrsValue, String> {
+    match args {
+        [SrsValue::String(cell)] => Ok(SrsValue::Integer(cell.borrow().len() as i64)),
+        [_] => Err("wrong type: expected string".to_string()),
+        [] => Err("not enough arguments to string-length".to_string()),
+        _ => Err("too many arguments to string-length".to_string()),
+    }
+}
+
+/// `(string-ref string k)`: returns the `k`-th character of `string`.
+fn native_string_ref(args: &[SrsValue]) -> Result<SrsValue, String> {
+    match args {
+        [SrsValue::String(cell), k] => {
+            let index = index_from(k, "string-ref")?;
+            cell.borrow()
+                .chars()
+                .nth(index)
+                .map(SrsValue::Character)
+                .ok_or_else(|| "string-ref: index out of range".to_string())
+        }
+        [_, _] => Err("wrong type: expected string and integer".to_string()),
+        [] | [_] => Err("not enough arguments to string-ref".to_string()),
+        _ => Err("too many arguments to string-ref".to_string()),
+    }
+}
+
+/// `(string=? string1 string2 ...)`: returns `#t` iff all arguments are
+/// strings with the same sequence of characters.
+fn native_string_eq(args: &[SrsValue]) -> Result<SrsValue, String> {
+    if args.is_empty() {
+        return Err("not enough arguments to string=?".to_string());
+    }
+    let first = match &args[0] {
+        SrsValue::String(cell) => cell.borrow().clone(),
+        _ => return Err("wrong type: expected string".to_string()),
+    };
+    for arg in &args[1..] {
+        match arg {
+            SrsValue::String(cell) => {
+                if cell.borrow().as_str() != first {
+                    return Ok(SrsValue::Boolean(false));
+                }
+            }
+            _ => return Err("wrong type: expected string".to_string()),
+        }
+    }
+    Ok(SrsValue::Boolean(true))
+}
+
+/// `(substring string start end)`: returns a freshly allocated string
+/// containing the characters from index `start` (inclusive) to `end`
+/// (exclusive).
+fn native_substring(args: &[SrsValue]) -> Result<SrsValue, String> {
+    match args {
+        [SrsValue::String(cell), start, end] => {
+            let s = cell.borrow();
+            let start = index_from(start, "substring")?;
+            let end = index_from(end, "substring")?;
+            if end > s.len() {
+                return Err("substring: index out of range".to_string());
+            }
+            if start > end {
+                return Err("substring: start index greater than end".to_string());
+            }
+            let sub: String = s.chars().skip(start).take(end - start).collect();
+            Ok(SrsValue::String(Rc::new(RefCell::new(sub))))
+        }
+        [_, _, _] => Err("wrong type: expected string".to_string()),
+        [] | [_] | [_, _] => Err("not enough arguments to substring".to_string()),
+        _ => Err("too many arguments to substring".to_string()),
+    }
+}
+
+/// `(string-append string ...)`: returns a freshly allocated string whose
+/// characters form the concatenation of the given strings.
+fn native_string_append(args: &[SrsValue]) -> Result<SrsValue, String> {
+    let mut result = String::new();
+    for arg in args {
+        match arg {
+            SrsValue::String(cell) => result.push_str(&cell.borrow()),
+            _ => return Err("wrong type: expected string".to_string()),
+        }
+    }
+    Ok(SrsValue::String(Rc::new(RefCell::new(result))))
+}
+
+/// `(list->string list)`: returns a freshly allocated string formed from
+/// the characters in `list`, which must be a proper list of characters.
+fn native_list_to_string(args: &[SrsValue]) -> Result<SrsValue, String> {
+    match args {
+        [list] => {
+            let items = list_to_vec(list).map_err(|e| e.to_string())?;
+            let mut result = String::with_capacity(items.len());
+            for item in items {
+                match item {
+                    SrsValue::Character(c) => result.push(c),
+                    _ => return Err("wrong type: expected list of characters".to_string()),
+                }
+            }
+            Ok(SrsValue::String(Rc::new(RefCell::new(result))))
+        }
+        [] => Err("not enough arguments to list->string".to_string()),
+        _ => Err("too many arguments to list->string".to_string()),
+    }
+}

--- a/libsrs/tests/r5rs/string_tests.rs
+++ b/libsrs/tests/r5rs/string_tests.rs
@@ -1,0 +1,91 @@
+use libsrs::interpretor::evaluator::{eval, global_env};
+use libsrs::interpretor::lexical_analyzer::get_lexemes;
+use libsrs::interpretor::reader::read_all;
+use libsrs::types::core::SrsValue;
+
+fn eval_src(scm: &str) -> SrsValue {
+    let values = read_all(get_lexemes(scm).unwrap()).unwrap();
+    let env = global_env();
+    let mut result = SrsValue::Unspecified;
+    for value in &values {
+        result = eval(value, &env).unwrap();
+    }
+    result
+}
+
+fn as_str(value: &SrsValue) -> String {
+    match value {
+        SrsValue::String(cell) => cell.borrow().clone(),
+        other => panic!("expected string, got {:?}", other),
+    }
+}
+
+#[test]
+fn string_p_recognizes_strings() {
+    assert!(matches!(eval_src("(string? \"hello\")"), SrsValue::Boolean(true)));
+    assert!(matches!(eval_src("(string? 123)"), SrsValue::Boolean(false)));
+}
+
+#[test]
+fn string_length_returns_character_count() {
+    assert!(matches!(eval_src("(string-length \"hello\")"), SrsValue::Integer(5)));
+}
+
+#[test]
+fn string_ref_returns_character_at_index() {
+    assert!(matches!(
+        eval_src("(string-ref \"hello\" 1)"),
+        SrsValue::Character('e')
+    ));
+}
+
+#[test]
+fn string_ref_out_of_range_is_an_error() {
+    let values = read_all(get_lexemes("(string-ref \"hi\" 5)").unwrap()).unwrap();
+    let env = global_env();
+    assert!(eval(&values[0], &env).is_err());
+}
+
+#[test]
+fn string_eq_compares_character_sequences() {
+    assert!(matches!(
+        eval_src("(string=? \"abc\" \"abc\")"),
+        SrsValue::Boolean(true)
+    ));
+    assert!(matches!(
+        eval_src("(string=? \"abc\" \"def\")"),
+        SrsValue::Boolean(false)
+    ));
+    assert!(matches!(
+        eval_src("(string=? \"a\" \"a\" \"a\")"),
+        SrsValue::Boolean(true)
+    ));
+}
+
+#[test]
+fn substring_extracts_slice() {
+    assert_eq!(as_str(&eval_src("(substring \"hello\" 1 4)")), "ell");
+}
+
+#[test]
+fn substring_start_equals_end_returns_empty() {
+    assert_eq!(as_str(&eval_src("(substring \"hello\" 2 2)")), "");
+}
+
+#[test]
+fn string_append_concatenates_arguments() {
+    assert_eq!(
+        as_str(&eval_src("(string-append \"foo\" \"bar\")")),
+        "foobar"
+    );
+}
+
+#[test]
+fn string_append_with_no_arguments_returns_empty_string() {
+    assert_eq!(as_str(&eval_src("(string-append)")), "");
+}
+
+#[test]
+fn list_to_string_converts_characters() {
+    assert_eq!(as_str(&eval_src("(list->string '(#\\f #\\o #\\o))")), "foo");
+}


### PR DESCRIPTION
Implements #65.

Adds R5RS string primitives:
- `string?`
- `string-length`
- `string-ref`
- `string=?`
- `substring`
- `string-append`
- `list->string`

Includes new test target `r5rs_string` and updated `r5rs_subset.md` coverage.

Closes #65