### PR TITLE
feat(natives): add open-input-file primitive

### DIFF
--- a/libsrs/doc/r5rs_subset.md
+++ b/libsrs/doc/r5rs_subset.md
@@ -83,10 +83,10 @@ insensibles à la casse, `make-string`, `string-copy`, `string-fill!`.
 
 `display` `newline` `write-char` `write-string` `read-char` `peek-char`
 `read-line` `char-ready?` `eof-object` `eof-object?` `current-input-port`
-`current-output-port` `open-input-string` `open-output-string`
+`current-output-port` `open-input-string` `open-input-file` `open-output-string`
 `get-output-string`
 
-Absents : `write`, `read`, `open-input-file`/`open-output-file`, etc.
+Absents : `write`, `read`, `open-output-file`, etc.
 
 ### Totalement absent
 

--- a/libsrs/src/interpretor/evaluator/natives/io.rs
+++ b/libsrs/src/interpretor/evaluator/natives/io.rs
@@ -98,6 +98,13 @@ pub(super) fn install(
         }),
     );
     env.define(
+        "open-input-file".to_string(),
+        SrsValue::Native(Native {
+            name: "open-input-file",
+            func: Rc::new(native_open_input_file),
+        }),
+    );
+    env.define(
         "open-output-string".to_string(),
         SrsValue::Native(Native {
             name: "open-output-string",
@@ -319,7 +326,7 @@ fn native_char_ready_p(
 ) -> Result<SrsValue, String> {
     let port = input_port_from_args("char-ready?", args, stdin_port)?;
     let ready = match &*port.borrow() {
-        PortData::InputStdin { .. } => true,
+        PortData::InputStdin { .. } | PortData::InputFile { .. } => true,
         PortData::InputString(chars, pos) => *pos < chars.len(),
         _ => false,
     };
@@ -336,6 +343,20 @@ fn native_open_input_string(args: &[SrsValue]) -> Result<SrsValue, String> {
         [] => Err("not enough arguments to open-input-string".to_string()),
         [_] => Err("wrong type: expected string".to_string()),
         _ => Err("too many arguments to open-input-string".to_string()),
+    }
+}
+
+/// `(open-input-file path)`: returns a new input port reading from file
+/// located at `path`.
+fn native_open_input_file(args: &[SrsValue]) -> Result<SrsValue, String> {
+    match args {
+        [SrsValue::String(s)] => Ok(SrsValue::Port(Rc::new(RefCell::new(
+            PortData::input_file(&*s.borrow())?,
+        )))),
+        [SrsValue::Symbol(_)] => Err("open-input-file: expected string".to_string()),
+        [] => Err("not enough arguments to open-input-file".to_string()),
+        [_] => Err("wrong type: expected string".to_string()),
+        _ => Err("too many arguments to open-input-file".to_string()),
     }
 }
 

--- a/libsrs/src/types/core.rs
+++ b/libsrs/src/types/core.rs
@@ -242,6 +242,16 @@ impl PortData {
         PortData::OutputString(String::new())
     }
 
+    /// Builds an input port reading from `path`, or returns an I/O error.
+    pub fn input_file<P: AsRef<std::path::Path>>(path: P) -> Result<Self, String> {
+        use std::fs::File;
+        let file = File::open(path).map_err(|e| format!("open-input-file: {}", e))?;
+        Ok(PortData::InputFile {
+            reader: BufReader::new(Box::new(file)),
+            peeked: None,
+        })
+    }
+
     /// Builds an input port from a byte slice, for unit tests.
     #[cfg(test)]
     pub fn test_input(data: &'static [u8]) -> Self {
@@ -252,15 +262,30 @@ impl PortData {
         }
     }
 
+/// Shared logic for reading/peeking one character from an
+    /// [`InputStdin`][PortData::InputStdin] or
+    /// [`InputFile`][PortData::InputFile] port.
+    fn take_or_read_peeked(
+        reader: &mut BufReader<Box<dyn Read>>,
+        peeked: &mut Option<char>,
+        take: bool,
+    ) -> Result<Option<char>, String> {
+        if let Some(c) = peeked.take() {
+            if !take {
+                *peeked = Some(c);
+            }
+            return Ok(Some(c));
+        }
+        read_char_from_reader(reader)
+    }
+
     /// Reads and consumes one character from the input port, returning
     /// [`SrsValue::Eof`] at end of file.
     pub fn read_char(&mut self) -> Result<SrsValue, String> {
         match self {
-            PortData::InputStdin { reader, peeked } => {
-                if let Some(c) = peeked.take() {
-                    return Ok(SrsValue::Character(c));
-                }
-                read_char_from_reader(reader)
+            PortData::InputStdin { reader, peeked }
+            | PortData::InputFile { reader, peeked } => {
+                Self::take_or_read_peeked(reader, peeked, true)
                     .map(|opt| opt.map(SrsValue::Character).unwrap_or(SrsValue::Eof))
             }
             PortData::InputString(chars, pos) => {
@@ -281,13 +306,11 @@ impl PortData {
     /// returning [`SrsValue::Eof`] at end of file.
     pub fn peek_char(&mut self) -> Result<SrsValue, String> {
         match self {
-            PortData::InputStdin { reader, peeked } => {
-                if let Some(c) = *peeked {
-                    return Ok(SrsValue::Character(c));
-                }
-                let c = read_char_from_reader(reader)?;
-                if let Some(ch) = c {
-                    *peeked = Some(ch);
+            PortData::InputStdin { reader, peeked }
+            | PortData::InputFile { reader, peeked } => {
+                let c = Self::take_or_read_peeked(reader, peeked, false)?;
+                if peeked.is_none() {
+                    *peeked = c;
                 }
                 Ok(c.map(SrsValue::Character).unwrap_or(SrsValue::Eof))
             }
@@ -308,7 +331,7 @@ impl PortData {
     pub fn is_input_port(&self) -> bool {
         matches!(
             self,
-            PortData::InputStdin { .. } | PortData::InputString(..)
+            PortData::InputStdin { .. } | PortData::InputFile { .. } | PortData::InputString(..)
         )
     }
 
@@ -322,14 +345,11 @@ impl PortData {
     /// yields EOF, returns [`SrsValue::Eof`].
     pub fn read_line(&mut self) -> Result<SrsValue, String> {
         match self {
-            PortData::InputStdin { reader, peeked } => {
+            PortData::InputStdin { reader, peeked }
+            | PortData::InputFile { reader, peeked } => {
                 let mut buf = String::new();
                 loop {
-                    let c = if let Some(c) = peeked.take() {
-                        Ok(Some(c))
-                    } else {
-                        read_char_from_reader(reader)
-                    };
+                    let c = Self::take_or_read_peeked(reader, peeked, true);
                     match c? {
                         Some('\n') => return Ok(SrsValue::String(Rc::new(RefCell::new(buf)))),
                         Some(ch) => buf.push(ch),
@@ -484,6 +504,11 @@ pub enum PortData {
         reader: BufReader<Box<dyn Read>>,
         peeked: Option<char>,
     },
+    /// File input backed by an opaque reader.
+    InputFile {
+        reader: BufReader<Box<dyn Read>>,
+        peeked: Option<char>,
+    },
     /// Standard output.
     OutputStdout,
     /// Input port reading characters from a string using a byte index.
@@ -497,6 +522,10 @@ impl fmt::Debug for PortData {
         match self {
             PortData::InputStdin { peeked, .. } => f
                 .debug_struct("InputStdin")
+                .field("peeked", peeked)
+                .finish(),
+            PortData::InputFile { peeked, .. } => f
+                .debug_struct("InputFile")
                 .field("peeked", peeked)
                 .finish(),
             PortData::OutputStdout => write!(f, "OutputStdout"),

--- a/libsrs/tests/r5rs/io_tests.rs
+++ b/libsrs/tests/r5rs/io_tests.rs
@@ -1,3 +1,5 @@
+use std::sync::atomic::{AtomicU64, Ordering};
+
 use libsrs::interpretor::evaluator::{eval, global_env};
 use libsrs::interpretor::lexical_analyzer::get_lexemes;
 use libsrs::interpretor::reader::read_all;
@@ -36,6 +38,20 @@ fn boolean_value(value: SrsValue) -> bool {
 
 fn eval_src(scm: &str) -> SrsValue {
     eval_all(scm).unwrap()
+}
+
+static TMP_COUNTER: AtomicU64 = AtomicU64::new(1);
+
+fn make_temp_file(contents: &str) -> String {
+    let dir = std::env::temp_dir();
+    let n = TMP_COUNTER.fetch_add(1, Ordering::SeqCst);
+    let path = dir.join(format!("s_rs_io_test_{}.txt", n));
+    std::fs::write(&path, contents).unwrap();
+    path.to_str().unwrap().to_string()
+}
+
+fn escape_path(path: &str) -> String {
+    path.replace('\\', "\\\\")
 }
 
 #[test]
@@ -227,6 +243,63 @@ fn read_line_on_string_port_returns_string_or_eof() {
 #[test]
 fn open_input_string_creates_input_port() {
     assert!(eval_all("(open-input-string \"hello\")").is_ok());
+}
+
+#[test]
+fn open_input_file_creates_input_port_from_real_file() {
+    let path = make_temp_file("line1\nline2\n");
+    let scm = format!("(open-input-file \"{}\")", escape_path(&path));
+    assert!(eval_all(&scm).is_ok());
+}
+
+#[test]
+fn open_input_file_reads_lines_and_chars() {
+    let path = make_temp_file("abc\ndef");
+    let scm = format!(
+        "(let ((p (open-input-file \"{}\")))
+            (read-line p)
+            (peek-char p)
+            (read-char p)
+            (read-line p))",
+        escape_path(&path)
+    );
+    assert_eq!(string_value(eval_src(&scm)), "ef");
+}
+
+#[test]
+fn open_input_file_peek_char_works() {
+    let path = make_temp_file("xy");
+    let scm = format!(
+        "(let ((p (open-input-file \"{}\")))
+            (peek-char p)
+            (read-char p))",
+        escape_path(&path)
+    );
+    assert_eq!(char_value(eval_src(&scm)), 'x');
+}
+
+#[test]
+fn open_input_file_returns_eof_after_last_line() {
+    let path = make_temp_file("only");
+    let scm = format!(
+        "(let ((p (open-input-file \"{}\")))
+            (read-line p)
+            (eof-object? (read-line p)))",
+        escape_path(&path)
+    );
+    assert!(boolean_value(eval_src(&scm)));
+}
+
+#[test]
+fn open_input_file_reports_missing_file() {
+    assert!(eval_all("(open-input-file \"/nonexistent/path/66.txt\")").is_err());
+}
+
+#[test]
+fn open_input_file_requires_string() {
+    assert!(eval_all("(open-input-file 42)").is_err());
+    assert!(eval_all("(open-input-file)").is_err());
+    assert!(eval_all("(open-input-file \"a\" \"b\")").is_err());
 }
 
 #[test]


### PR DESCRIPTION
Closes #66

- Adds PortData::InputFile mirroring the buffered-reader pattern used by InputStdin.
- Wires the new variant through read_char, peek_char, read_line, is_input_port, and char-ready?.
- Implements open-input-file in natives/io.rs with clear errors for missing files or wrong argument counts.
- Adds integration tests using temporary files and updates r5rs_subset.md.

cargo test passes.