### PR TITLE
feat(natives): add list, reverse, pair? primitives

### DIFF
--- a/libsrs/doc/r5rs_subset.md
+++ b/libsrs/doc/r5rs_subset.md
@@ -54,15 +54,16 @@ Absents : `atan` à 2 arguments, `exp`, `log`.
 
 ### Paires et listes (`natives/pairs.rs`)
 
-`cons` `car` `cdr` `apply` `map` `length` `null?` `eq?`
+`cons` `car` `cdr` `apply` `map` `length` `null?` `eq?` `list` `reverse`
+`pair?`
 
 `eq?` compare l'identité des objets mutables (`Rc::ptr_eq`), et les
 valeurs atomiques par valeur (deux nombres égaux comptent comme
 égaux pour `eq?`, conformément à R5RS).
 
-Absents : `pair?`, `list?`, `list`, `set-car!`, `set-cdr!`, `append`,
-`reverse`, `list-ref`, `list-tail`, `memq`/`memv`/`member`,
-`assq`/`assv`/`assoc`, `for-each`, `caar`/`cadr`/..., `eqv?`/`equal?`.
+Absents : `list?`, `set-car!`, `set-cdr!`, `append`, `list-ref`,
+`list-tail`, `memq`/`memv`/`member`, `assq`/`assv`/`assoc`,
+`for-each`, `caar`/`cadr`/..., `eqv?`/`equal?`.
 
 ### Vecteurs (`natives/vectors.rs`)
 

--- a/libsrs/src/interpretor/evaluator/natives/io.rs
+++ b/libsrs/src/interpretor/evaluator/natives/io.rs
@@ -350,9 +350,9 @@ fn native_open_input_string(args: &[SrsValue]) -> Result<SrsValue, String> {
 /// located at `path`.
 fn native_open_input_file(args: &[SrsValue]) -> Result<SrsValue, String> {
     match args {
-        [SrsValue::String(s)] => Ok(SrsValue::Port(Rc::new(RefCell::new(
-            PortData::input_file(&*s.borrow())?,
-        )))),
+        [SrsValue::String(s)] => Ok(SrsValue::Port(Rc::new(RefCell::new(PortData::input_file(
+            &*s.borrow(),
+        )?)))),
         [SrsValue::Symbol(_)] => Err("open-input-file: expected string".to_string()),
         [] => Err("not enough arguments to open-input-file".to_string()),
         [_] => Err("wrong type: expected string".to_string()),

--- a/libsrs/src/interpretor/evaluator/natives/pairs.rs
+++ b/libsrs/src/interpretor/evaluator/natives/pairs.rs
@@ -63,6 +63,27 @@ pub(super) fn install(env: &Rc<Env>) {
             func: Rc::new(native_eq_p),
         }),
     );
+    env.define(
+        "list".to_string(),
+        SrsValue::Native(Native {
+            name: "list",
+            func: Rc::new(native_list),
+        }),
+    );
+    env.define(
+        "reverse".to_string(),
+        SrsValue::Native(Native {
+            name: "reverse",
+            func: Rc::new(native_reverse),
+        }),
+    );
+    env.define(
+        "pair?".to_string(),
+        SrsValue::Native(Native {
+            name: "pair?",
+            func: Rc::new(native_pair_p),
+        }),
+    );
 }
 
 /// `(cons car cdr)`: allocates a fresh mutable pair.
@@ -156,6 +177,36 @@ fn native_is_null(args: &[SrsValue]) -> Result<SrsValue, String> {
         [obj] => Ok(SrsValue::Boolean(matches!(obj, SrsValue::Nil))),
         [] => Err("not enough arguments to null?".to_string()),
         _ => Err("too many arguments to null?".to_string()),
+    }
+}
+
+/// `(list obj ...)`: returns a newly allocated proper list of its arguments
+/// (R5RS section 6.3.2).
+fn native_list(args: &[SrsValue]) -> Result<SrsValue, String> {
+    Ok(vec_to_list(args.to_vec()))
+}
+
+/// `(reverse list)`: returns a newly allocated list whose elements are the
+/// elements of `list` in reverse order (R5RS section 6.3.2).
+fn native_reverse(args: &[SrsValue]) -> Result<SrsValue, String> {
+    match args {
+        [list] => {
+            let mut items = list_to_vec(list).map_err(|e| e.to_string())?;
+            items.reverse();
+            Ok(vec_to_list(items))
+        }
+        [] => Err("not enough arguments to reverse".to_string()),
+        _ => Err("too many arguments to reverse".to_string()),
+    }
+}
+
+/// `(pair? obj)`: returns `#t` if `obj` is a pair, `#f` otherwise
+/// (R5RS section 6.3.2).
+fn native_pair_p(args: &[SrsValue]) -> Result<SrsValue, String> {
+    match args {
+        [obj] => Ok(SrsValue::Boolean(matches!(obj, SrsValue::Pair(_)))),
+        [] => Err("not enough arguments to pair?".to_string()),
+        _ => Err("too many arguments to pair?".to_string()),
     }
 }
 

--- a/libsrs/src/types/core.rs
+++ b/libsrs/src/types/core.rs
@@ -262,7 +262,7 @@ impl PortData {
         }
     }
 
-/// Shared logic for reading/peeking one character from an
+    /// Shared logic for reading/peeking one character from an
     /// [`InputStdin`][PortData::InputStdin] or
     /// [`InputFile`][PortData::InputFile] port.
     fn take_or_read_peeked(
@@ -283,8 +283,7 @@ impl PortData {
     /// [`SrsValue::Eof`] at end of file.
     pub fn read_char(&mut self) -> Result<SrsValue, String> {
         match self {
-            PortData::InputStdin { reader, peeked }
-            | PortData::InputFile { reader, peeked } => {
+            PortData::InputStdin { reader, peeked } | PortData::InputFile { reader, peeked } => {
                 Self::take_or_read_peeked(reader, peeked, true)
                     .map(|opt| opt.map(SrsValue::Character).unwrap_or(SrsValue::Eof))
             }
@@ -306,8 +305,7 @@ impl PortData {
     /// returning [`SrsValue::Eof`] at end of file.
     pub fn peek_char(&mut self) -> Result<SrsValue, String> {
         match self {
-            PortData::InputStdin { reader, peeked }
-            | PortData::InputFile { reader, peeked } => {
+            PortData::InputStdin { reader, peeked } | PortData::InputFile { reader, peeked } => {
                 let c = Self::take_or_read_peeked(reader, peeked, false)?;
                 if peeked.is_none() {
                     *peeked = c;
@@ -345,8 +343,7 @@ impl PortData {
     /// yields EOF, returns [`SrsValue::Eof`].
     pub fn read_line(&mut self) -> Result<SrsValue, String> {
         match self {
-            PortData::InputStdin { reader, peeked }
-            | PortData::InputFile { reader, peeked } => {
+            PortData::InputStdin { reader, peeked } | PortData::InputFile { reader, peeked } => {
                 let mut buf = String::new();
                 loop {
                     let c = Self::take_or_read_peeked(reader, peeked, true);
@@ -524,10 +521,9 @@ impl fmt::Debug for PortData {
                 .debug_struct("InputStdin")
                 .field("peeked", peeked)
                 .finish(),
-            PortData::InputFile { peeked, .. } => f
-                .debug_struct("InputFile")
-                .field("peeked", peeked)
-                .finish(),
+            PortData::InputFile { peeked, .. } => {
+                f.debug_struct("InputFile").field("peeked", peeked).finish()
+            }
             PortData::OutputStdout => write!(f, "OutputStdout"),
             PortData::InputString(chars, pos) => f
                 .debug_tuple("InputString")

--- a/libsrs/tests/r5rs/pair_tests.rs
+++ b/libsrs/tests/r5rs/pair_tests.rs
@@ -76,3 +76,65 @@ fn null_returns_false_for_a_pair() {
         SrsValue::Boolean(false)
     ));
 }
+
+#[test]
+fn pair_returns_true_for_a_pair() {
+    assert!(matches!(
+        eval_src("(pair? (cons 1 2))"),
+        SrsValue::Boolean(true)
+    ));
+}
+
+#[test]
+fn pair_returns_false_for_the_empty_list() {
+    assert!(matches!(eval_src("(pair? '())"), SrsValue::Boolean(false)));
+}
+
+#[test]
+fn pair_returns_false_for_an_atom() {
+    assert!(matches!(eval_src("(pair? 42)"), SrsValue::Boolean(false)));
+}
+
+#[test]
+fn list_returns_the_empty_list_when_given_no_arguments() {
+    assert!(matches!(eval_src("(list)"), SrsValue::Nil));
+}
+
+#[test]
+fn list_builds_a_proper_list_from_arguments() {
+    assert!(matches!(
+        eval_src("(car (list 1 2 3))"),
+        SrsValue::Integer(1)
+    ));
+    assert!(matches!(
+        eval_src("(car (cdr (list 1 2 3)))"),
+        SrsValue::Integer(2)
+    ));
+    assert!(matches!(
+        eval_src("(length (list 1 2 3))"),
+        SrsValue::Integer(3)
+    ));
+}
+
+#[test]
+fn reverse_reverses_a_proper_list() {
+    let src = "(reverse '(1 2 3))";
+    assert!(matches!(eval_src(src), SrsValue::Pair(_)));
+    assert!(matches!(
+        eval_src("(car (reverse '(1 2 3)))"),
+        SrsValue::Integer(3)
+    ));
+    assert!(matches!(
+        eval_src("(car (cdr (reverse '(1 2 3))))"),
+        SrsValue::Integer(2)
+    ));
+    assert!(matches!(
+        eval_src("(car (cdr (cdr (reverse '(1 2 3)))))"),
+        SrsValue::Integer(1)
+    ));
+}
+
+#[test]
+fn reverse_returns_the_empty_list_for_the_empty_list() {
+    assert!(matches!(eval_src("(reverse '())"), SrsValue::Nil));
+}

--- a/libsrs/tests/r5rs/string_tests.rs
+++ b/libsrs/tests/r5rs/string_tests.rs
@@ -22,13 +22,22 @@ fn as_str(value: &SrsValue) -> String {
 
 #[test]
 fn string_p_recognizes_strings() {
-    assert!(matches!(eval_src("(string? \"hello\")"), SrsValue::Boolean(true)));
-    assert!(matches!(eval_src("(string? 123)"), SrsValue::Boolean(false)));
+    assert!(matches!(
+        eval_src("(string? \"hello\")"),
+        SrsValue::Boolean(true)
+    ));
+    assert!(matches!(
+        eval_src("(string? 123)"),
+        SrsValue::Boolean(false)
+    ));
 }
 
 #[test]
 fn string_length_returns_character_count() {
-    assert!(matches!(eval_src("(string-length \"hello\")"), SrsValue::Integer(5)));
+    assert!(matches!(
+        eval_src("(string-length \"hello\")"),
+        SrsValue::Integer(5)
+    ));
 }
 
 #[test]


### PR DESCRIPTION
Ajoute les primitives manquantes `list`, `reverse` et `pair?` dans `natives/pairs.rs`.\n\n- `list` construit une liste propre à partir de ses arguments.\n- `reverse` retourne une nouvelle liste dans l'ordre inverse.\n- `pair?` retourne `#t` pour une paire, `#f` sinon.\n\nTests ajoutés dans `pair_tests.rs` et `r5rs_subset.md` mis à jour. Inclut également un formatage `cargo fmt` sur les fichiers concernés.\n\nCloses #67