### PR TITLE
feat(srsgtk): add draw-point primitive

### DIFF
--- a/srsgtk/doc/graphics_api.md
+++ b/srsgtk/doc/graphics_api.md
@@ -15,6 +15,7 @@ rendu.
 | `clear-canvas` | `()` | Vide la liste des commandes de dessin enregistrées |
 | `set-color` | `(r g b)` | Couleur courante pour les dessins suivants, composantes flottantes 0..1 |
 | `draw-line` | `(x1 y1 x2 y2)` | Trace une ligne |
+| `draw-point` | `(x y)` | Trace un point (disque plein de rayon fixe 2 px) |
 | `draw-rect` | `(x y w h)` | Trace un rectangle |
 | `draw-circle` | `(x y r)` | Trace un cercle |
 | `canvas-width` | `()` | Largeur courante du canvas (Integer) |
@@ -27,6 +28,7 @@ rendu.
 (set-color 1.0 0.0 0.0)
 (draw-rect 10 10 100 50)
 (draw-circle 200 200 40)
+(draw-point 50 50)
 ```
 
 ## Limitations connues

--- a/srsgtk/src/graphics.rs
+++ b/srsgtk/src/graphics.rs
@@ -59,6 +59,12 @@ enum DrawCommand {
         r: f64,
         color: Color,
     },
+    Point {
+        x: f64,
+        y: f64,
+        r: f64,
+        color: Color,
+    },
 }
 
 /// Shared canvas state: the commands recorded so far, the color used by
@@ -107,7 +113,7 @@ fn call_redraw_hook(state: &Rc<RefCell<CanvasState>>) {
 }
 
 /// Installs the graphics primitives (`clear-canvas`, `set-color`,
-/// `draw-line`, `draw-rect`, `draw-circle`) into `env`, wired to redraw
+/// `draw-line`, `draw-rect`, `draw-circle`, `draw-point`) into `env`, wired to redraw
 /// `drawing_area` via Cairo.
 pub fn install(env: &Rc<Env>, drawing_area: &DrawingArea) {
     let state = Rc::new(RefCell::new(CanvasState::new()));
@@ -156,6 +162,11 @@ pub fn install(env: &Rc<Env>, drawing_area: &DrawingArea) {
                         cr.set_source_rgb(color.r, color.g, color.b);
                         cr.arc(*x, *y, *r, 0.0, std::f64::consts::TAU);
                         let _ = cr.stroke();
+                    }
+                    DrawCommand::Point { x, y, r, color } => {
+                        cr.set_source_rgb(color.r, color.g, color.b);
+                        cr.arc(*x, *y, *r, 0.0, std::f64::consts::TAU);
+                        let _ = cr.fill();
                     }
                 }
             }
@@ -252,6 +263,28 @@ pub fn install(env: &Rc<Env>, drawing_area: &DrawingArea) {
                 .borrow_mut()
                 .commands
                 .push(DrawCommand::Circle { x, y, r, color });
+            drawing_area.queue_draw();
+            Ok(SrsValue::Unspecified)
+        }
+    });
+
+    define_native(env, "draw-point", {
+        let state = state.clone();
+        let drawing_area = drawing_area.clone();
+        move |args| {
+            let [x, y] = args else {
+                return Err("draw-point: expected 2 arguments (x y)".to_string());
+            };
+            let x = numeric_to_f64(x, "draw-point")?;
+            let y = numeric_to_f64(y, "draw-point")?;
+            const POINT_RADIUS: f64 = 2.0;
+            let color = state.borrow().current_color;
+            state.borrow_mut().commands.push(DrawCommand::Point {
+                x,
+                y,
+                r: POINT_RADIUS,
+                color,
+            });
             drawing_area.queue_draw();
             Ok(SrsValue::Unspecified)
         }


### PR DESCRIPTION
Closes #79

Ajoute la primitive graphique "(draw-point x y)" à srsgtk.

- Nouveau variant DrawCommand::Point { x, y, r, color } dans srsgtk/src/graphics.rs.
- Rendu Cairo via arc() + fill(), contrairement à draw-circle qui utilise stroke().
- Rayon fixe de 2 px, comme demandé dans l'issue.
- Documentation mise à jour dans srsgtk/doc/graphics_api.md.

DoD :
- [x] (draw-point x y) disponible depuis un script .scm
- [x] Documentation à jour
- [x] cargo fmt / cargo clippy / cargo test passent