### PR TITLE
feat(pairs): add R5RS composed cxr procedures (cadr..cddddr)

### DIFF
--- a/libsrs/src/interpretor/evaluator/natives/pairs.rs
+++ b/libsrs/src/interpretor/evaluator/natives/pairs.rs
@@ -28,6 +28,7 @@ pub(super) fn install(env: &Rc<Env>) {
             func: Rc::new(native_cdr),
         }),
     );
+    install_cxr(env);
     env.define(
         "apply".to_string(),
         SrsValue::Native(Native {
@@ -115,6 +116,75 @@ fn native_cdr(args: &[SrsValue]) -> Result<SrsValue, String> {
         [_] => Err("wrong type: expected pair".to_string()),
         [] => Err("not enough arguments to cdr".to_string()),
         _ => Err("too many arguments to cdr".to_string()),
+    }
+}
+
+type CxrOp = fn(SrsValue) -> Result<SrsValue, String>;
+
+/// Registers the R5RS composed pair accessors `caar`...`cddddr`.
+fn install_cxr(env: &Rc<Env>) {
+    // Right-to-left as in R5RS: each character from the right becomes car/cdr.
+    let cxrs: &[(&str, &[CxrOp])] = &[
+        ("caar", &[car, car]),
+        ("cadr", &[car, cdr]),
+        ("cdar", &[cdr, car]),
+        ("cddr", &[cdr, cdr]),
+        ("caaar", &[car, car, car]),
+        ("caadr", &[car, car, cdr]),
+        ("cadar", &[car, cdr, car]),
+        ("caddr", &[car, cdr, cdr]),
+        ("cdaar", &[cdr, car, car]),
+        ("cdadr", &[cdr, car, cdr]),
+        ("cddar", &[cdr, cdr, car]),
+        ("cdddr", &[cdr, cdr, cdr]),
+        ("caaaar", &[car, car, car, car]),
+        ("caaadr", &[car, car, car, cdr]),
+        ("caadar", &[car, car, cdr, car]),
+        ("caaddr", &[car, car, cdr, cdr]),
+        ("cadaar", &[car, cdr, car, car]),
+        ("cadadr", &[car, cdr, car, cdr]),
+        ("caddar", &[car, cdr, cdr, car]),
+        ("cadddr", &[car, cdr, cdr, cdr]),
+        ("cdaaar", &[cdr, car, car, car]),
+        ("cdaadr", &[cdr, car, car, cdr]),
+        ("cdadar", &[cdr, car, cdr, car]),
+        ("cdaddr", &[cdr, car, cdr, cdr]),
+        ("cddaar", &[cdr, cdr, car, car]),
+        ("cddadr", &[cdr, cdr, car, cdr]),
+        ("cdddar", &[cdr, cdr, cdr, car]),
+        ("cddddr", &[cdr, cdr, cdr, cdr]),
+    ];
+    for (name, ops) in cxrs {
+        let ops: Vec<CxrOp> = ops.to_vec();
+        env.define(
+            (*name).to_string(),
+            SrsValue::Native(Native {
+                name,
+                func: Rc::new(move |args| cxr_apply(name, args, &ops)),
+            }),
+        );
+    }
+}
+
+fn car(value: SrsValue) -> Result<SrsValue, String> {
+    match value {
+        SrsValue::Pair(cell) => Ok(cell.borrow().0.clone()),
+        _ => Err("wrong type: expected pair".to_string()),
+    }
+}
+
+fn cdr(value: SrsValue) -> Result<SrsValue, String> {
+    match value {
+        SrsValue::Pair(cell) => Ok(cell.borrow().1.clone()),
+        _ => Err("wrong type: expected pair".to_string()),
+    }
+}
+
+fn cxr_apply(name: &str, args: &[SrsValue], ops: &[CxrOp]) -> Result<SrsValue, String> {
+    match args {
+        [value] => ops.iter().rev().try_fold(value.clone(), |acc, op| op(acc)),
+        [] => Err(format!("not enough arguments to {}", name)),
+        _ => Err(format!("too many arguments to {}", name)),
     }
 }
 

--- a/libsrs/tests/r5rs/pair_tests.rs
+++ b/libsrs/tests/r5rs/pair_tests.rs
@@ -1,16 +1,20 @@
-use libsrs::interpretor::evaluator::{eval, global_env};
+use libsrs::interpretor::evaluator::{eval, global_env, EvalError};
 use libsrs::interpretor::lexical_analyzer::get_lexemes;
 use libsrs::interpretor::reader::read_all;
 use libsrs::types::core::SrsValue;
 
 fn eval_src(scm: &str) -> SrsValue {
+    eval_src_result(scm).unwrap()
+}
+
+fn eval_src_result(scm: &str) -> Result<SrsValue, EvalError> {
     let values = read_all(get_lexemes(scm).unwrap()).unwrap();
     let env = global_env();
     let mut result = SrsValue::Unspecified;
     for value in &values {
-        result = eval(value, &env).unwrap();
+        result = eval(value, &env)?;
     }
-    result
+    Ok(result)
 }
 
 #[test]
@@ -137,4 +141,42 @@ fn reverse_reverses_a_proper_list() {
 #[test]
 fn reverse_returns_the_empty_list_for_the_empty_list() {
     assert!(matches!(eval_src("(reverse '())"), SrsValue::Nil));
+}
+
+#[test]
+fn composed_cxr_level_2() {
+    // (cadr '((1 2) (3 4) (5 6))) => car(cdr '((1 2) (3 4) (5 6))) => (3 4)
+    assert!(matches!(
+        eval_src("(cadr '((1 2) (3 4) (5 6)))"),
+        SrsValue::Pair(_)
+    ));
+    // (cdar '((1 2) 3)) => cdr(car) => (2)
+    assert!(matches!(eval_src("(cdar '((1 2) 3))"), SrsValue::Pair(_)));
+}
+
+#[test]
+fn composed_cxr_level_3() {
+    // (caddr '(1 2 3 4)) => 3
+    assert!(matches!(eval_src("(caddr '(1 2 3 4))"), SrsValue::Integer(3)));
+    // (caaar '(((42)))) => 42
+    assert!(matches!(
+        eval_src("(caaar '(((42))))"),
+        SrsValue::Integer(42)
+    ));
+}
+
+#[test]
+fn composed_cxr_level_4() {
+    // (cadddr '(1 2 3 4 5)) => 4
+    assert!(matches!(
+        eval_src("(cadddr '(1 2 3 4 5))"),
+        SrsValue::Integer(4)
+    ));
+    // (cddddr '(1 2 3 4 5)) => (5)
+    assert!(matches!(eval_src("(cddddr '(1 2 3 4 5))"), SrsValue::Pair(_)));
+}
+
+#[test]
+fn composed_cxr_errors_on_non_pair() {
+    assert!(eval_src_result("(cadr 1)").is_err());
 }


### PR DESCRIPTION
Closes #88.

Implements all 28 R5RS composed pair accessors (`caar` through `cddddr`) as native procedures, applied right-to-left as defined by R5RS.

- Added `install_cxr` in `pairs.rs` to register `caar`, `cadr`, ..., `cddddr`.
- Shared helpers `car`/`cdr` raise `wrong type: expected pair` consistently with existing primitives.
- Added tests covering level 2, 3 and 4 accessors plus a wrong-type error case.