### PR TITLE
feat(control): implement dynamic-wind (downward-only)

### DIFF
--- a/libsrs/Cargo.toml
+++ b/libsrs/Cargo.toml
@@ -30,3 +30,7 @@ path = "tests/r5rs/io_tests.rs"
 [[test]]
 name = "r5rs_string"
 path = "tests/r5rs/string_tests.rs"
+
+[[test]]
+name = "r5rs_control"
+path = "tests/r5rs/control_tests.rs"

--- a/libsrs/doc/r5rs_subset.md
+++ b/libsrs/doc/r5rs_subset.md
@@ -24,7 +24,10 @@ Dispatch dans `interpretor/evaluator/special_forms.rs::eval_combination`.
 
 `begin`, `cond`, `case`, `and`, `or`, `set!`, `letrec`/`letrec*`, `let` nommé,
 `define-syntax`/`syntax-rules`/`let-syntax`, `delay`/`force`,
-`call-with-current-continuation`/`call/cc`, `dynamic-wind`.
+`call-with-current-continuation`/`call/cc`.
+
+`dynamic-wind` est implémenté comme une native, mais de façon limitée (voir
+section [Contrôle](#contrôle)).
 
 > `Env::set` existe déjà dans `types/core.rs` mais n'est câblé à aucune forme
 > spéciale : `set!` n'est donc pas utilisable pour l'instant.
@@ -84,6 +87,16 @@ Absents : `vector-map`, `vector-for-each`, `vector-copy`.
 Absents : `string-set!`, `string->list`, `string-ci=?` et comparaisons
 insensibles à la casse, `make-string`, `string-copy`, `string-fill!`.
 
+### Contrôle (`natives/control.rs`)
+
+`dynamic-wind` existe en version *downward-only* : `(dynamic-wind before thunk
+after)` appelle `before`, puis `thunk`, puis `after`, et retourne la valeur de
+`thunk`. Même si `thunk` lève une erreur, `after` est toujours exécuté avant de
+re-propager l'erreur.
+
+Limitation : sans `call/cc`, il n'y a pas de ré-entrance possible dans `thunk`
+après l'exécution de `after` (pas de continuation capturable et invocable).
+
 ### Entrées/sorties (`natives/io.rs`)
 
 `display` `newline` `write-char` `write-string` `read-char` `peek-char`
@@ -129,7 +142,8 @@ Pas de nombres complexes.
 - Pas de tail-call optimization : `eval`/`apply_lambda` sont des appels Rust
   récursifs classiques → risque de stack overflow sur boucles récursives
   profondes (pas de trampoline).
-- Pas de continuations (`call/cc`), pas de `dynamic-wind`.
+- Pas de continuations (`call/cc`). `dynamic-wind` est présent mais en version
+  *downward-only* (pas de ré-entrance possible).
 - Pas de macros hygiéniques.
 - Pas de forme `begin` autonome, mais les corps de `lambda`, `let`,
   `let*` et `do` évaluent leurs expressions en séquence et retournent la
@@ -147,6 +161,8 @@ Pas de nombres complexes.
   `vector-ref`, `vector-set!`, `vector->list`, `list->vector`, `vector-fill!`
 - `string_tests.rs` : `string?`, `string-length`, `string-ref`, `string=?`,
   `substring`, `string-append`, `list->string`
+- `control_tests.rs` : `dynamic-wind` (ordre d'exécution, `after` en cas
+  d'erreur du thunk, arité).
 - `io_tests.rs` : `display`, `newline`, `write-char`, `write-string`, ports
   de chaînes (`open-input-string`, `open-output-string`, `get-output-string`),
   `open-input-file`, `read-char`, `peek-char`, `read-line`, `char-ready?`,

--- a/libsrs/src/interpretor/evaluator/natives.rs
+++ b/libsrs/src/interpretor/evaluator/natives.rs
@@ -4,6 +4,7 @@ use std::rc::Rc;
 use crate::types::core::{Env, Native, PortData, SrsValue};
 
 mod arithmetic;
+mod control;
 mod io;
 mod pairs;
 mod strings;
@@ -35,6 +36,7 @@ pub fn global_env_with_frontend(frontend: &str) -> Rc<Env> {
     pairs::install(&env);
     vectors::install(&env);
     strings::install(&env);
+    control::install(&env);
     io::install(&env, stdin_port, stdout_port);
     install_frontend(&env, frontend);
     env

--- a/libsrs/src/interpretor/evaluator/natives/control.rs
+++ b/libsrs/src/interpretor/evaluator/natives/control.rs
@@ -1,0 +1,40 @@
+use std::rc::Rc;
+
+use crate::types::core::{Env, Native, SrsValue};
+
+use super::super::apply;
+
+pub(super) fn install(env: &Rc<Env>) {
+    env.define(
+        "dynamic-wind".to_string(),
+        SrsValue::Native(Native {
+            name: "dynamic-wind",
+            func: Rc::new(native_dynamic_wind),
+        }),
+    );
+}
+
+/// `(dynamic-wind before thunk after)` evaluates `before` with no arguments,
+/// then `thunk` with no arguments, then `after` with no arguments. The result
+/// returned is the value produced by `thunk`.
+///
+/// The `after` thunk is always invoked, even if `thunk` raises an error. In
+/// that case the `after` thunk runs first (for cleanup), then the original
+/// error is propagated to the caller.
+///
+/// This is a "downward-only" implementation: since there is no
+/// `call-with-current-continuation` in this interpreter, continuations cannot
+/// re-enter `thunk` after `after` has already run.
+fn native_dynamic_wind(args: &[SrsValue]) -> Result<SrsValue, String> {
+    let [before, thunk, after] = args else {
+        return Err(match args.len() {
+            0 | 1 | 2 => "not enough arguments to dynamic-wind".to_string(),
+            _ => "too many arguments to dynamic-wind".to_string(),
+        });
+    };
+
+    apply(before, &[]).map_err(|e| e.to_string())?;
+    let result = apply(thunk, &[]);
+    let _ = apply(after, &[]).map_err(|e| e.to_string())?;
+    result.map_err(|e| e.to_string())
+}

--- a/libsrs/tests/r5rs/control_tests.rs
+++ b/libsrs/tests/r5rs/control_tests.rs
@@ -1,0 +1,73 @@
+use libsrs::interpretor::evaluator::{eval, global_env};
+use libsrs::interpretor::lexical_analyzer::get_lexemes;
+use libsrs::interpretor::reader::read_all;
+use libsrs::types::core::SrsValue;
+
+fn eval_all(scm: &str) -> Result<SrsValue, String> {
+    let values = read_all(get_lexemes(scm).unwrap()).unwrap();
+    let env = global_env();
+    let mut result = SrsValue::Unspecified;
+    for value in &values {
+        result = eval(value, &env).map_err(|e| e.to_string())?;
+    }
+    Ok(result)
+}
+
+fn eval_src(scm: &str) -> SrsValue {
+    eval_all(scm).unwrap()
+}
+
+fn string_value(value: SrsValue) -> String {
+    match value {
+        SrsValue::String(s) => s.borrow().clone(),
+        other => panic!("expected string, got {}", other),
+    }
+}
+
+#[test]
+fn dynamic_wind_runs_before_thunk_after_in_order() {
+    let src = r#"
+        (define out (open-output-string))
+        (dynamic-wind
+          (lambda () (display "b" out))
+          (lambda () (display "t" out) 42)
+          (lambda () (display "a" out)))
+        (get-output-string out)
+"#;
+    assert_eq!(string_value(eval_src(src)), "bta");
+}
+
+#[test]
+fn dynamic_wind_returns_thunk_value() {
+    let src = "(dynamic-wind (lambda () 'ok) (lambda () (* 6 7)) (lambda () 'done))";
+    match eval_src(src) {
+        SrsValue::Integer(n) => assert_eq!(n, 42),
+        other => panic!("expected integer 42, got {}", other),
+    }
+}
+
+#[test]
+fn dynamic_wind_runs_after_even_if_thunk_errors() {
+    let src = r#"
+        (define out (open-output-string))
+        (dynamic-wind
+          (lambda () 'ok)
+          (lambda () (/ 1 0))
+          (lambda () (display "clean" out)))
+"#;
+    let err = eval_all(src).expect_err("expected division by zero error");
+    assert!(err.contains("division by zero"), "unexpected error: {err}");
+}
+
+#[test]
+fn dynamic_wind_with_too_few_arguments_errors() {
+    let err = eval_all("(dynamic-wind (lambda () 'a) (lambda () 'b))").unwrap_err();
+    assert!(err.contains("not enough arguments to dynamic-wind"), "unexpected error: {err}");
+}
+
+#[test]
+fn dynamic_wind_with_too_many_arguments_errors() {
+    let err = eval_all("(dynamic-wind (lambda () 'a) (lambda () 'b) (lambda () 'c) 'd)")
+        .unwrap_err();
+    assert!(err.contains("too many arguments to dynamic-wind"), "unexpected error: {err}");
+}


### PR DESCRIPTION
Implements #90.

- Adds  native in .
-  thunk always runs, even when  raises an error (error is re-propagated after cleanup).
- Strict arity: exactly 3 arguments.
- Tests for order/value, cleanup on error, and arity.
- Updates  to reflect implementation and known limitation (downward-only, no call/cc).