### PR TITLE
feat(csv): streaming rows, char=? parse and close-input-port

### DIFF
--- a/libs/csv.scm
+++ b/libs/csv.scm
@@ -8,42 +8,65 @@
     "Parse LINE into a list of field strings, splitting on DELIMITER."
     (let ((len (string-length line))
           (d (string-ref delimiter 0)))
-      (define csv-parse-line-loop
-        (lambda (i field fields)
-          (if (= i len)
-              (reverse (cons (list->string (reverse field)) fields))
-              (let ((c (string-ref line i)))
-                (if (string=? (list->string (list c)) (list->string (list d)))
-                    (csv-parse-line-loop
-                     (+ i 1)
-                     '()
-                     (cons (list->string (reverse field)) fields))
-                    (csv-parse-line-loop
-                     (+ i 1)
-                     (cons c field)
-                     fields))))))
-      (csv-parse-line-loop 0 '() '()))))
+      (do ((i 0 (+ i 1))
+           (field '() (if (char=? (string-ref line i) d)
+                          '()
+                          (cons (string-ref line i) field)))
+           (fields '() (if (char=? (string-ref line i) d)
+                           (cons (list->string (reverse field)) fields)
+                           fields)))
+          ((= i len) (reverse (cons (list->string (reverse field)) fields)))
+        'ok))))
+
+(define csv-call-with-file
+  (lambda (path delimiter callback)
+    "Open PATH as a streaming CSV, parse the header once, then call CALLBACK
+with (NEXT-ROW HEADER). NEXT-ROW returns the next parsed row as a list of
+field strings, or '() at EOF. The input port is closed on normal return or
+if CALLBACK raises an error."
+    (let ((port (open-input-file path)))
+      (define next-row
+        (lambda ()
+          (let ((line (read-line port)))
+            (if (eof-object? line)
+                '()
+                (if (= (string-length line) 0)
+                    (next-row)
+                    (csv-parse-line line delimiter))))))
+      (let ((header (next-row)))
+        (dynamic-wind
+          (lambda () 'ok)
+          (lambda () (callback next-row header))
+          (lambda () (close-input-port port)))))))
+
+(define csv-for-each-row
+  (lambda (path delimiter row-fn)
+    "Iterate over the data rows of the CSV at PATH. For each row, call
+ROW-FN with (HEADER ROW). The file is read lazily, one line at a time."
+    (csv-call-with-file
+      path
+      delimiter
+      (lambda (next-row header)
+        (define first-row (next-row))
+        (do ((row first-row (next-row)))
+            ((null? row) 'done)
+          (row-fn header row))))))
 
 (define csv-read-file
   (lambda (path delimiter)
     "Read the CSV file at PATH and return (cons header-vector rows-vector)."
-    (let ((port (open-input-file path)))
-      (define read-lines
-        (lambda (acc)
-          (let ((line (read-line port)))
-            (if (eof-object? line)
-                (reverse acc)
-                (if (= (string-length line) 0)
-                    (read-lines acc)
-                    (read-lines (cons line acc)))))))
-      (let ((lines (read-lines '())))
-        (if (null? lines)
-            (cons (vector) (vector))
-            (cons (list->vector (csv-parse-line (car lines) delimiter))
-                  (list->vector
-                   (map (lambda (line)
-                          (list->vector (csv-parse-line line delimiter)))
-                        (cdr lines)))))))))
+    (csv-call-with-file
+      path
+      delimiter
+      (lambda (next-row header)
+        (define collect
+          (lambda (acc)
+            (let ((row (next-row)))
+              (if (null? row)
+                  (reverse acc)
+                  (collect (cons row acc))))))
+        (cons (list->vector header)
+              (list->vector (map list->vector (collect '()))))))))
 
 (define csv-header
   (lambda (csv)

--- a/libsrs/doc/r5rs_subset.md
+++ b/libsrs/doc/r5rs_subset.md
@@ -102,7 +102,7 @@ après l'exécution de `after` (pas de continuation capturable et invocable).
 `display` `newline` `write-char` `write-string` `read-char` `peek-char`
 `read-line` `char-ready?` `eof-object` `eof-object?` `current-input-port`
 `current-output-port` `open-input-string` `open-input-file` `open-output-string`
-`get-output-string`
+`get-output-string` `close-input-port`
 
 Absents : `write`, `read`, `open-output-file`, etc.
 
@@ -165,5 +165,5 @@ Pas de nombres complexes.
   d'erreur du thunk, arité).
 - `io_tests.rs` : `display`, `newline`, `write-char`, `write-string`, ports
   de chaînes (`open-input-string`, `open-output-string`, `get-output-string`),
-  `open-input-file`, `read-char`, `peek-char`, `read-line`, `char-ready?`,
-  `eof-object`, `current-input-port`, `current-output-port`
+  `open-input-file`, `close-input-port`, `read-char`, `peek-char`, `read-line`,
+  `char-ready?`, `eof-object`, `current-input-port`, `current-output-port`

--- a/libsrs/src/interpretor/evaluator/natives/io.rs
+++ b/libsrs/src/interpretor/evaluator/natives/io.rs
@@ -132,6 +132,13 @@ pub(super) fn install(
             func: Rc::new(move |args| native_write_string(args, &stdout_for_write_string)),
         }),
     );
+    env.define(
+        "close-input-port".to_string(),
+        SrsValue::Native(Native {
+            name: "close-input-port",
+            func: Rc::new(native_close_input_port),
+        }),
+    );
 }
 
 /// `(display value [port])`: writes `value` to the output port using its
@@ -381,6 +388,21 @@ fn native_get_output_string(args: &[SrsValue]) -> Result<SrsValue, String> {
         }
         [] => Err("not enough arguments to get-output-string".to_string()),
         _ => Err("wrong type: expected output-string port".to_string()),
+    }
+}
+
+/// `(close-input-port port)`: closes the input port, releasing its underlying
+/// resources. Subsequent reads return EOF.
+fn native_close_input_port(args: &[SrsValue]) -> Result<SrsValue, String> {
+    match args {
+        [SrsValue::Port(port)] if port.borrow().is_input_port() => {
+            port.borrow_mut().close();
+            Ok(SrsValue::Unspecified)
+        }
+        [] => Err("not enough arguments to close-input-port".to_string()),
+        [SrsValue::Port(_)] => Err("close-input-port: not an input port".to_string()),
+        [_] => Err("wrong type: expected input port".to_string()),
+        _ => Err("too many arguments to close-input-port".to_string()),
     }
 }
 

--- a/libsrs/src/interpretor/evaluator/natives/strings.rs
+++ b/libsrs/src/interpretor/evaluator/natives/strings.rs
@@ -56,6 +56,13 @@ pub(super) fn install(env: &Rc<Env>) {
             func: Rc::new(native_list_to_string),
         }),
     );
+    env.define(
+        "char=?".to_string(),
+        SrsValue::Native(Native {
+            name: "char=?",
+            func: Rc::new(native_char_eq),
+        }),
+    );
 }
 
 /// `(string? obj)`: returns `#t` if `obj` is a string, `#f` otherwise.
@@ -172,4 +179,27 @@ fn native_list_to_string(args: &[SrsValue]) -> Result<SrsValue, String> {
         [] => Err("not enough arguments to list->string".to_string()),
         _ => Err("too many arguments to list->string".to_string()),
     }
+}
+
+/// `(char=? char1 char2 ...)`: returns `#t` iff all arguments are the same
+/// character.
+fn native_char_eq(args: &[SrsValue]) -> Result<SrsValue, String> {
+    if args.is_empty() {
+        return Err("not enough arguments to char=?".to_string());
+    }
+    let first = match &args[0] {
+        SrsValue::Character(c) => *c,
+        _ => return Err("wrong type: expected character".to_string()),
+    };
+    for arg in &args[1..] {
+        match arg {
+            SrsValue::Character(c) => {
+                if *c != first {
+                    return Ok(SrsValue::Boolean(false));
+                }
+            }
+            _ => return Err("wrong type: expected character".to_string()),
+        }
+    }
+    Ok(SrsValue::Boolean(true))
 }

--- a/libsrs/src/types/core.rs
+++ b/libsrs/src/types/core.rs
@@ -242,6 +242,24 @@ impl PortData {
         PortData::OutputString(String::new())
     }
 
+    /// Closes an input port, releasing its underlying resources.
+    ///
+    /// File and stdin ports are replaced by an empty reader so the OS handle
+    /// is dropped; string ports are drained. Subsequent reads return EOF.
+    pub fn close(&mut self) {
+        match self {
+            PortData::InputStdin { reader, peeked } | PortData::InputFile { reader, peeked } => {
+                *reader = BufReader::new(Box::new(std::io::empty()));
+                *peeked = None;
+            }
+            PortData::InputString(chars, pos) => {
+                chars.clear();
+                *pos = 0;
+            }
+            _ => {}
+        }
+    }
+
     /// Builds an input port reading from `path`, or returns an I/O error.
     pub fn input_file<P: AsRef<std::path::Path>>(path: P) -> Result<Self, String> {
         use std::fs::File;

--- a/libsrs/tests/csv_tests.rs
+++ b/libsrs/tests/csv_tests.rs
@@ -1,0 +1,212 @@
+use std::rc::Rc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Instant;
+
+use libsrs::interpretor::evaluator::{eval, global_env};
+use libsrs::interpretor::lexical_analyzer::get_lexemes;
+use libsrs::interpretor::reader::read_all;
+use libsrs::types::core::SrsValue;
+
+fn eval_all(scm: &str) -> Result<SrsValue, String> {
+    eval_all_in_env(scm, &global_env())
+}
+
+fn eval_all_in_env(scm: &str, env: &Rc<libsrs::types::core::Env>) -> Result<SrsValue, String> {
+    let values = read_all(get_lexemes(scm).unwrap()).unwrap();
+    let mut result = SrsValue::Unspecified;
+    for value in &values {
+        result = eval(value, env).map_err(|e| e.to_string())?;
+    }
+    Ok(result)
+}
+
+fn eval_src(scm: &str) -> SrsValue {
+    eval_all(scm).unwrap()
+}
+
+fn integer_value(value: SrsValue) -> i64 {
+    match value {
+        SrsValue::Integer(n) => n,
+        other => panic!("expected integer, got {}", other),
+    }
+}
+
+static TMP_COUNTER: AtomicU64 = AtomicU64::new(1);
+
+fn make_temp_file(contents: &str) -> String {
+    let dir = std::env::temp_dir();
+    let n = TMP_COUNTER.fetch_add(1, Ordering::SeqCst);
+    let path = dir.join(format!("s_rs_csv_test_{}.csv", n));
+    std::fs::write(&path, contents).unwrap();
+    path.to_str().unwrap().to_string()
+}
+
+fn escape_path(path: &str) -> String {
+    path.replace('\\', "\\\\")
+}
+
+fn csv_lib_path() -> String {
+    let manifest = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let lib_path = manifest.parent().unwrap().join("libs").join("csv.scm");
+    escape_path(lib_path.to_str().unwrap())
+}
+
+#[test]
+fn csv_read_file_parses_comma_fixture() {
+    let manifest = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let fixture = escape_path(manifest.join("tests/fixtures/csv/users.csv").to_str().unwrap());
+    let lib = csv_lib_path();
+    let src = format!(
+        "(load \"{}\") (define csv (csv-read-file \"{}\" \",\")) (vector-length (csv-header csv))",
+        lib, fixture
+    );
+    assert_eq!(integer_value(eval_src(&src)), 3);
+}
+
+#[test]
+fn csv_read_file_parses_semicolon_fixture() {
+    let manifest = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let fixture = escape_path(manifest.join("tests/fixtures/csv/users_semicolon.csv").to_str().unwrap());
+    let lib = csv_lib_path();
+    let src = format!(
+        "(load \"{}\") (define csv (csv-read-file \"{}\" \";\")) (vector-length (csv-header csv))",
+        lib, fixture
+    );
+    assert_eq!(integer_value(eval_src(&src)), 3);
+}
+
+#[test]
+fn csv_for_each_row_iterates_all_rows() {
+    let manifest = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let fixture = escape_path(manifest.join("tests/fixtures/csv/users.csv").to_str().unwrap());
+    let lib = csv_lib_path();
+    let src = format!(
+        "(load \"{}\")
+         (define out (open-output-string))
+         (csv-for-each-row \"{}\" \",\" (lambda (h r) (display \"x\" out)))
+         (string-length (get-output-string out))",
+        lib, fixture
+    );
+    assert_eq!(integer_value(eval_src(&src)), 3);
+}
+
+#[test]
+fn csv_for_each_row_header_is_stable_and_parsed() {
+    let manifest = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let fixture = escape_path(manifest.join("tests/fixtures/csv/users.csv").to_str().unwrap());
+    let lib = csv_lib_path();
+    let src = format!(
+        "(load \"{}\")
+         (define out (open-output-string))
+         (csv-for-each-row \"{}\" \",\" (lambda (h r) (display (car h) out)))
+         (get-output-string out)",
+        lib, fixture
+    );
+    let result = match eval_src(&src) {
+        SrsValue::String(s) => s.borrow().clone(),
+        other => panic!("expected string, got {}", other),
+    };
+    assert_eq!(result, "prenomprenomprenom");
+}
+
+#[test]
+fn csv_for_each_row_handles_empty_file() {
+    let path = make_temp_file("");
+    let lib = csv_lib_path();
+    let src = format!(
+        "(load \"{}\")
+         (define out (open-output-string))
+         (csv-for-each-row \"{}\" \",\" (lambda (h r) (display \"x\" out)))
+         (string-length (get-output-string out))",
+        lib, escape_path(&path)
+    );
+    assert_eq!(integer_value(eval_src(&src)), 0);
+}
+
+#[test]
+fn csv_call_with_file_propagates_callback_error() {
+    // The underlying dynamic-wind already guarantees that the port is closed
+    // even when the callback raises (see control_tests). This test only checks
+    // that csv-call-with-file does not swallow errors from the callback.
+    let manifest = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let fixture = escape_path(manifest.join("tests/fixtures/csv/users.csv").to_str().unwrap());
+    let lib = csv_lib_path();
+    let src = format!(
+        "(load \"{}\")\n         (csv-call-with-file \"{}\" \",\" (lambda (next-row header) (/ 1 0)))",
+        lib, fixture
+    );
+    let err = eval_all(&src).expect_err("expected division by zero");
+    assert!(err.contains("division by zero"), "unexpected error: {err}");
+}
+
+#[test]
+fn csv_parse_line_char_eq_bench() {
+    // Benchmark of the char=? optimization requested in issue #91.
+    // The naive version allocates a fresh string for every character it
+    // compares to the delimiter; the optimized version compares characters
+    // directly. Both parsers are loaded once into a shared environment; the
+    // CSV line is read from a temp file so the measurement does not pay the
+    // cost of lexing a huge string literal in the test source.
+    let lib = csv_lib_path();
+    let env = global_env();
+    eval_all_in_env(
+        &format!(
+            "(load \"{}\")
+             (define csv-parse-line-naive
+               (lambda (line delimiter)
+                 (let ((len (string-length line)) (d (string-ref delimiter 0)))
+                   (do ((i 0 (+ i 1))
+                        (field '() (if (string=? (list->string (list (string-ref line i)))
+                                                (list->string (list d)))
+                                       '()
+                                       (cons (string-ref line i) field)))
+                        (fields '() (if (string=? (list->string (list (string-ref line i)))
+                                                (list->string (list d)))
+                                        (cons (list->string (reverse field)) fields)
+                                        fields)))
+                       ((= i len) (reverse (cons (list->string (reverse field)) fields)))
+                     'ok))))",
+            lib
+        ),
+        &env,
+    )
+    .unwrap();
+
+    let fast_input = "a,b,c,".repeat(1_667); // ~10_000 characters
+    let fast_path = make_temp_file(&fast_input);
+    let fast_src = format!(
+        "(define p (open-input-file \"{}\")) (define line (read-line p)) (close-input-port p) (length (csv-parse-line line \",\"))",
+        escape_path(&fast_path)
+    );
+    let start = Instant::now();
+    let fast_len = integer_value(eval_all_in_env(&fast_src, &env).unwrap());
+    let fast_elapsed = start.elapsed();
+    assert_eq!(fast_len, 3 * 1_667 + 1);
+
+    let naive_input = "a,b,c,".repeat(167); // ~1_000 characters
+    let naive_path = make_temp_file(&naive_input);
+    let naive_src = format!(
+        "(define p (open-input-file \"{}\")) (define line (read-line p)) (close-input-port p) (length (csv-parse-line-naive line \",\"))",
+        escape_path(&naive_path)
+    );
+    let start = Instant::now();
+    let naive_len = integer_value(eval_all_in_env(&naive_src, &env).unwrap());
+    let naive_elapsed = start.elapsed();
+    assert_eq!(naive_len, 3 * 167 + 1);
+
+    let fast_per_char = fast_elapsed.as_nanos() as f64 / fast_input.len() as f64;
+    let naive_per_char = naive_elapsed.as_nanos() as f64 / naive_input.len() as f64;
+    eprintln!(
+        "csv-parse-line perf: char=? {:?} ({} chars), naive {:?} ({} chars); per-char: {:.1} ns / {:.1} ns",
+        fast_elapsed,
+        fast_input.len(),
+        naive_elapsed,
+        naive_input.len(),
+        fast_per_char,
+        naive_per_char
+    );
+
+    // Smoke check: both versions must complete in a reasonable amount of time.
+    assert!(fast_elapsed.as_secs() < 10, "char=? parser is unexpectedly slow");
+    assert!(naive_elapsed.as_secs() < 10, "naive parser is unexpectedly slow");
+}

--- a/libsrs/tests/r5rs/io_tests.rs
+++ b/libsrs/tests/r5rs/io_tests.rs
@@ -420,3 +420,36 @@ fn write_string_requires_string() {
 fn write_string_with_too_many_args_fails() {
     assert!(eval_all("(let ((p (open-output-string))) (write-string \"a\" p 0 1 2))").is_err());
 }
+
+#[test]
+fn close_input_port_closes_file_port() {
+    let path = make_temp_file("line1\nline2\n");
+    let scm = format!(
+        "(let ((p (open-input-file \"{}\")))
+            (close-input-port p)
+            (eof-object? (read-line p)))",
+        escape_path(&path)
+    );
+    assert!(boolean_value(eval_src(&scm)));
+}
+
+#[test]
+fn close_input_port_closes_string_port() {
+    let src = r#"
+        (let ((p (open-input-string "abc")))
+          (close-input-port p)
+          (eof-object? (read-char p)))
+    "#;
+    assert!(boolean_value(eval_src(src)));
+}
+
+#[test]
+fn close_input_port_requires_input_port() {
+    assert!(eval_all("(close-input-port (current-output-port))").is_err());
+}
+
+#[test]
+fn close_input_port_arity() {
+    assert!(eval_all("(close-input-port)").is_err());
+    assert!(eval_all("(close-input-port (open-input-string \"x\") 2)").is_err());
+}


### PR DESCRIPTION
Closes #91.

- csv-parse-line now compares characters directly with char=? instead of allocating one-character strings.
- Rewrote the parser iteratively with do to avoid stack overflow on long lines.
- Added streaming API:
  - internal csv-call-with-file opens a CSV, parses the header once, exposes a next-row thunk, and guarantees the port is closed via dynamic-wind.
  - public csv-for-each-row iterates row by row without materialising the whole file.
- Kept csv-read-file for small files, rebuilt on top of the streaming primitive.
- Added close-input-port native and char=? native.
- Added tests and a perf benchmark comparing the char=? parser with the previous string-allocation approach.

Definition of done:
- [x] csv-parse-line uses char=?
- [x] csv-for-each-row available and functional
- [x] csv-call-with-file stays internal
- [x] Tests added and passing
- [x] Perf benchmark documented (before/after numbers printed by the test)